### PR TITLE
Added support for local and remote address id

### DIFF
--- a/include/linux/dccp.h
+++ b/include/linux/dccp.h
@@ -174,11 +174,9 @@ struct dccp_request_sock {
 	struct list_head	 dreq_featneg;
 	__u32			 dreq_timestamp_echo;
 	__u32			 dreq_timestamp_time;
-#if IS_ENABLED(CONFIG_IP_MPDCCP)
-	struct mpdccp_link_info  *link_info;
-#endif
 	int 			id_rcv;
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
+	struct mpdccp_link_info  *link_info;
 	struct mpdccp_key	mpdccp_loc_key;
 	struct mpdccp_key	mpdccp_rem_key;
 	u32			mpdccp_loc_token;
@@ -210,19 +208,14 @@ struct dccp_options_received {
 	u32	dccpor_elapsed_time;
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 	u64 dccpor_oall_seq:48;		/* MPDCCP overall sequence number */
-	u32 dccpor_delay;			/* MPDCCP delay transmission */
-	u32 dccpor_path_id;			/* MPDCCP delay transmission */
-#endif
-	u32 dccpor_delpath_rcv;
-#if IS_ENABLED(CONFIG_IP_MPDCCP)
 	u8 dccpor_mp_suppkeys;			/* MPDCCP supported key types */
 	u32 dccpor_mp_token;			/* MPDCCP path token */
 	u32 dccpor_mp_nonce;			/* MPDCCP path nonce */
 	u8 dccpor_mp_hmac[MPDCCP_HMAC_SIZE];	/* MPDCCP HMAC */
 	struct mpdccp_key dccpor_mp_keys[MPDCCP_MAX_KEYS];	/* MPDCCP keys */
-#endif
 	int saw_mpkey;
 	int saw_mpjoin;
+	#endif
 };
 
 struct ccid;

--- a/include/uapi/linux/dccp.h
+++ b/include/uapi/linux/dccp.h
@@ -185,12 +185,9 @@ enum {
 	DCCPO_MP_HMAC = 5,					/* HMA Code for authentication */
 	DCCPO_MP_RTT = 6,						/* Transmit RTT values */
 	DCCPO_MP_ADDADDR = 7,				/* (unused): Option for adding an address from behind a firewall */
-	DCCPO_MP_DELPATH = 8,				/* (unused): Option for deleting an address from behind a firewall */
+	DCCPO_MP_REMOVEADDR = 8,				/* (unused): Option for deleting an address from behind a firewall */
 	DCCPO_MP_PRIO = 9,					/* path priorization */
-	DCCPO_MP_DELAY = 10,				/* MPDCCP delay value transmission */
-	DCCPO_MP_PATH_INFO = 11,
-	DCCPO_MP_PATH_ID = 12,
-	DCCPO_MP_PATH_TYPE = 13,
+	DCCPO_MP_CLOSE = 10,				/* Close MPDCCP flow */
 };
 
 /* DCCP CCIDS */

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -143,6 +143,8 @@ unset_mpdccp(struct sock *sk) {
     list_for_each_entry_rcu(mpcb, &list, connection_list)
 
 
+#define chk_id(x,y) (x != y) ? x : 0
+
 /**
  * mpdccp_list_first_or_null_rcu - get the first element from a list
  * @ptr:        the list head to take the element from.
@@ -231,6 +233,9 @@ struct mpdccp_cb {
 	spinlock_t              plisten_list_lock;
 	/* Pointer to list of request sockets (client side) */
 	struct list_head __rcu  prequest_list;
+	/* Pointer to list of remote addresses (initial and learned) */
+	struct list_head __rcu  premote_list;
+
 	
 	int     multipath_active;
 	
@@ -253,7 +258,9 @@ struct mpdccp_cb {
 	u16			    server_port;	// Server only 
 	int			    backlog;
 	int			up_reported;
-	
+	u8 			master_addr_id;
+	int  		cnt_remote_addrs;
+
 	/* Scheduler related data */
 	struct mpdccp_sched_ops *sched_ops;
 	int			    has_own_sched;
@@ -304,6 +311,10 @@ struct my_sock
 	int			link_cnt;
 	int			link_iscpy;
 	int			up_reported;
+	
+	/* Address ID related data */
+	u8 local_addr_id;
+	u8 remote_addr_id;
 	
 	/* Path manager related data */
 	int     if_idx; /* Interface ID, used for event handling */
@@ -397,6 +408,9 @@ static inline struct sock *dccp_sk_inv(const struct dccp_sock *dp)
 	return (struct sock *)dp;
 }
 
+static inline u8 get_id(struct sock *sk){
+    return chk_id(mpdccp_my_sock(sk)->local_addr_id, mpdccp_my_sock(sk)->mpcb->master_addr_id);
+}
 
 
 #endif /* _MPDCCP_H */

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -252,7 +252,6 @@ struct mpdccp_cb {
 	int                     remaddr_len;	// length of mpdccp_remote_addr;
 	u16			    server_port;	// Server only 
 	int			    backlog;
-	int                     delpath;
 	int			up_reported;
 	
 	/* Scheduler related data */

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -247,10 +247,12 @@ struct mpdccp_cb *mpdccp_alloc_mpcb(void)
     INIT_LIST_HEAD(&mpcb->psubflow_list);
     INIT_LIST_HEAD(&mpcb->plisten_list);
     INIT_LIST_HEAD(&mpcb->prequest_list);
+    INIT_LIST_HEAD(&mpcb->premote_list);
     spin_lock_init(&mpcb->psubflow_list_lock);
     spin_lock_init(&mpcb->plisten_list_lock);
 
     mpcb->cnt_subflows      = 0;
+    mpcb->cnt_remote_addrs  = 0;
     mpcb->multipath_active  = 1;     //socket option; always active for now
     mpcb->dsn_local  = 0;
     mpcb->dsn_remote = 0;
@@ -266,6 +268,7 @@ struct mpdccp_cb *mpdccp_alloc_mpcb(void)
     mpcb->mpdccp_rem_key.type  = DCCPK_INVALID;
     mpcb->mpdccp_rem_key.size  = 0;
     mpcb->cur_key_idx = 0;
+    mpcb->master_addr_id = 0;
 
     mpdccp_init_path_manager(mpcb);
     mpdccp_init_scheduler(mpcb);
@@ -295,7 +298,10 @@ int mpdccp_destroy_mpcb(struct mpdccp_cb *mpcb)
 	list_del_rcu(&mpcb->connection_list);
 	INIT_LIST_HEAD(&mpcb->connection_list);
 	spin_unlock(&pconnection_list_lock);
-	
+
+	if(mpcb->pm_ops->free_remote_addr)
+		mpcb->pm_ops->free_remote_addr(mpcb);
+
 	/* close all subflows */
 	list_for_each_safe(pos, temp, &((mpcb)->psubflow_list)) {
 		mysk = list_entry(pos, struct my_sock, sk_list);
@@ -735,8 +741,25 @@ int mpdccp_add_client_conn (	struct mpdccp_cb *mpcb,
 		goto out;
 	}
 	if (local_address->sa_family == AF_INET) {
+        int loc_id = 0;
+        union inet_addr addr;
 		struct sockaddr_in 	*local_v4_address = (struct sockaddr_in*)local_address;
 		link_info = mpdccp_link_find_ip4 (&init_net, &local_v4_address->sin_addr, NULL);
+
+        addr.in = local_v4_address->sin_addr;
+        if(mpcb->pm_ops->get_local_id)
+            loc_id = mpcb->pm_ops->get_local_id(mpcb->meta_sk, AF_INET, &addr, 0);
+
+        if(loc_id < 0){
+            dccp_pr_debug("cant create subflow with unknown address id");
+		    sock_release(sock);
+		    goto out;
+        }
+        if(mpcb->master_addr_id == 0){
+            mpcb->master_addr_id = loc_id;
+            dccp_pr_debug("master_addr_id set %u", mpcb->master_addr_id);
+        }
+        mpdccp_my_sock(sk)->local_addr_id = loc_id;
 	} else if (local_address->sa_family == AF_INET6) {
 		struct sockaddr_in6 	*local_v6_address = (struct sockaddr_in6*)local_address;
 		link_info = mpdccp_link_find_ip6 (&init_net, &local_v6_address->sin6_addr, NULL);
@@ -746,6 +769,7 @@ int mpdccp_add_client_conn (	struct mpdccp_cb *mpcb,
 	mpdccp_my_sock(sk)->link_info = link_info;
 	mpdccp_my_sock(sk)->link_cnt = mpdccp_link_cnt(link_info);
 	mpdccp_my_sock(sk)->link_iscpy = 0;
+	mpdccp_my_sock(sk)->remote_addr_id = 0;
 
 	/* Add socket to the request list */
 	spin_lock(&mpcb->psubflow_list_lock);

--- a/net/dccp/mpdccp_pm.h
+++ b/net/dccp/mpdccp_pm.h
@@ -51,6 +51,8 @@ struct mpdccp_pm_ns {
 	
 	struct list_head	events;
 	struct delayed_work	address_worker;
+
+	u8 loc4_bits;
 	
 	struct net		*net;
 };
@@ -64,8 +66,13 @@ struct mpdccp_pm_ns {
 struct mpdccp_pm_ops {
 	struct list_head	list;
 	
-	int			(*add_init_server_conn) (struct mpdccp_cb*, int backlog);
-	int			(*add_init_client_conn) (struct mpdccp_cb*, struct sockaddr *, int);
+	int			(*add_init_server_conn) (struct mpdccp_cb*, int);
+	int			(*add_init_client_conn) (struct mpdccp_cb*, struct sockaddr*, int);
+	int			(*get_local_id)         (const struct sock*, sa_family_t, union inet_addr*, int);
+	void		(*rm_remote_addr)       (u8);
+	void		(*add_remote_addr)      (struct mpdccp_cb*, sa_family_t, u8, union inet_addr*, u16);
+	int			(*get_remote_id)		(struct mpdccp_cb*, union inet_addr*, sa_family_t);
+	void		(*free_remote_addr)     (struct mpdccp_cb*);
 	
 	char			name[MPDCCP_PM_NAME_MAX];
 	struct module		*owner;

--- a/net/dccp/mpdccp_proto.c
+++ b/net/dccp/mpdccp_proto.c
@@ -665,7 +665,9 @@ create_subflow(
 	struct sock *meta_sk,
 	struct sk_buff *skb,
 	struct request_sock *req,
-	int clone)
+	int clone,
+	u8 loc_addr_id,
+	u8 rem_addr_id)
 {
 	int ret;
 	struct sock *newsk;
@@ -673,7 +675,7 @@ create_subflow(
 	struct mpdccp_link_info *link_info = NULL;
 	struct dccp_request_sock *dreq = dccp_rsk(req);
 
-	mpdccp_pr_debug("enter sk %p meta %p req %p clone %d\n", sk, meta_sk, req, clone);
+	mpdccp_pr_debug("enter sk %p meta %p req %p clone %d loc_id %u rem_id %u\n", sk, meta_sk, req, clone, loc_addr_id, rem_addr_id);
 	if (clone) {
 		bool own;
 		/* Use the dccp request flow to create a clone of the meta socket */
@@ -720,6 +722,8 @@ create_subflow(
 	mpdccp_my_sock(newsk)->link_info = link_info;
 	mpdccp_my_sock(newsk)->link_cnt = mpdccp_link_cnt(link_info);
 	mpdccp_my_sock(newsk)->link_iscpy = 0;
+    mpdccp_my_sock(newsk)->local_addr_id = loc_addr_id;
+    mpdccp_my_sock(newsk)->remote_addr_id = rem_addr_id;
 
 	spin_lock(&mpcb->psubflow_list_lock);
 	list_add_tail_rcu(&mpdccp_my_sock(newsk)->sk_list, &mpcb->psubflow_list);
@@ -758,6 +762,7 @@ _mpdccp_create_master(
 	struct sockaddr_in sin;
 	struct inet_sock *inet = inet_sk(child);
 	struct dccp_request_sock *dreq = dccp_rsk(req);
+	union inet_addr addr;
 
 	mpdccp_pr_debug("enter for sk %p child %p dreq %p\n", sk, child, dreq);
 
@@ -783,9 +788,20 @@ _mpdccp_create_master(
 	mpcb->cur_key_idx = 0;
 	mpcb->mpdccp_rem_key = dreq->mpdccp_rem_key;
 	mpcb->role = MPDCCP_SERVER;
+	mpcb->master_addr_id = 0;
+
+	addr.ip = inet->inet_saddr;
+	if(mpcb->pm_ops->get_local_id)
+		mpcb->master_addr_id = mpcb->pm_ops->get_local_id(meta_sk, AF_INET, &addr, 0);
+
+	mpdccp_pr_debug("master subflow id: %u\n", mpcb->master_addr_id);
+
+	addr.ip = inet->inet_daddr;
+	if(mpcb->pm_ops->add_remote_addr)
+		mpcb->pm_ops->add_remote_addr(mpcb, AF_INET, 0, &addr, inet->inet_dport);
 
 	/* Create subflow and meta sockets */
-	ret = create_subflow(sk, meta_sk, skb, req, 1);
+	ret = create_subflow(sk, meta_sk, skb, req, 1, mpcb->master_addr_id, 0);
 	if (ret < 0) {
 		mpdccp_pr_debug("error creating subflow %d\n", ret);
 		goto err_sub;
@@ -893,6 +909,8 @@ static int _mpdccp_check_req(struct sock *sk, struct sock *newsk, struct request
 		/* This is a new subflow socket */
 		u8 hash_mac[20];
 		u8 msg[8];
+		int loc_id = 0, rem_id = 0;
+		union inet_addr addr;
 
 		struct sock *meta_sk = dreq->meta_sk;
 		if (!meta_sk) {
@@ -923,8 +941,17 @@ static int _mpdccp_check_req(struct sock *sk, struct sock *newsk, struct request
 		}
 		mpdccp_pr_debug("HMAC validation OK");
 
+		if(mpcb->pm_ops->get_local_id && mpcb->pm_ops->get_remote_id){
+			addr.ip = ip_hdr(skb)->daddr;
+			loc_id = mpcb->pm_ops->get_local_id(mpcb->meta_sk, AF_INET, &addr, 0);
+			if(loc_id < 0){
+				mpdccp_pr_debug("cant create subflow with unknown address id");
+				return -1;
+			}
+		}
 		/* Now add the subflow to the mpcb */
-		ret = create_subflow(newsk, meta_sk, skb, req, 0);//_mpdccp_listen(newsk, 1);
+
+		ret = create_subflow(newsk, meta_sk, skb, req, 0, (u8)loc_id, 0);//_mpdccp_listen(newsk, 1);
 		if (ret) {
 			mpdccp_pr_debug("error mpdccp_create_master_sub %d", ret);
 			return -1;

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -27,6 +27,7 @@
 #include "feat.h"
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 #  include "mpdccp.h"
+#  include "mpdccp_pm.h"
 #  include <net/mpdccp.h>
 #endif
 

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -50,76 +50,6 @@ u64 dccp_decode_value_var(const u8 *bf, const u8 len)
 	return value;
 }
 
-// static void mpdccp_send_reset_rem_id(const struct mpdccp_cb *mpcb, u8 rem_id)
-// {
-// 	// struct sock *sk_it, *tmpsk;
-
-// 	// mpdccp_for_each_sk_safe(mpcb, sk_it, tmpsk) {
-// 	// 	if (sk_it->sk_user_data->rem_id == rem_id) {
-// 	// 		mpdccp_reinject_data(sk_it, 0);
-// 	// 		mpdccp_send_reset(sk_it);
-// 	// 	}
-// 	// }
-// }
-
-// static void mpdccp_handle_add_addr(const unsigned char *ptr, struct sock *sk, sa_family_t family)
-// {
-// 	struct mp_add_addr 	*mpadd = (struct mp_add_addr *)ptr;
-// 	struct my_sock 		*my_sk;
-//     struct mpdccp_cb 	*mpcb;
-// 	union inet_addr 	addr;
-// 	__be16 				port = 0;
-
-// 	if(!sk || !sk->sk_user_data)
-//         return;
-
-//     my_sk = sk->sk_user_data;
-// 	mpcb = my_sk->mpcb;
-
-// 	if (family == AF_INET) {
-// 		port  = mpadd->u.v4.port;
-// 		addr.in = mpadd->u.v4.addr;
-// #if IS_ENABLED(CONFIG_IPV6)
-// 	} else if (family == AF_INET6) {
-// 		port  = mpadd->u.v6.port;
-// 		addr.in6 = mpadd->u.v6.addr;
-// #endif /* CONFIG_IPV6 */
-// 	} else {
-// 		return;
-// 	}
-
-// 	if (mpcb->pm_ops->add_raddr)
-// 		mpcb->pm_ops->add_raddr(mpcb, &addr, family, port, mpadd->addr_id);
-// }
-
-// static void mpdccp_handle_del_addr(const unsigned char *ptr, struct sock *sk, short len)
-// {
-// 	struct mp_delete_addr *mpdel = (struct mp_delete_addr *)ptr;
-// 	int i;
-// 	u8 rem_id;
-// 	struct my_sock 		*my_sk;
-//     struct mpdccp_cb 	*mpcb;
-
-//     if(!sk || !sk->sk_user_data)
-//         return;
-
-//     my_sk = sk->sk_user_data;
-// 	mpcb = my_sk->mpcb;
-
-// 	/* Compared to MPTCP, our address IDs have 16 bits. This may change in
-// 	 * a later version, in this case change this back to i++ */
-// 	 for (i = 0; i <= len - MPDCCP_LEN_DEL_ADDR; i+=2) {
-// 		 rem_id = (&mpdel->addrs_id)[i];
-
-// 		rem_id = mpdel->addrs_id;
-
-// 		if (mpcb->pm_ops->rem_raddr)
-// 			mpcb->pm_ops->rem_raddr(mpcb, rem_id);
-// 		mpdccp_send_reset_rem_id(mpcb, rem_id);
-
-// 	 }
-// }
-
 /**
  * dccp_parse_options  -  Parse DCCP options present in @skb
  * @sk: client|server|listening dccp socket (when @dreq != NULL)
@@ -142,10 +72,6 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 	__be32 opt_val;
 	int rc;
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
-	u64 oall_seq = 0;	//MPDCCP overall seqno
-	u32 delay = 0;		//MPDCCP delay report
-	u32 path_id = 0;    //MPDCCP path_id
-	u32 del_path = 0;    //MPDCCP path_id
 	u8 mp_opt = 0;
 #endif
 	int mandatory = 0;
@@ -307,48 +233,10 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 			mp_opt = *value++;
 			len--;
 			switch(mp_opt) {
-			case DCCPO_MP_SEQ:
-				//TODO reordering, use 48 bit > 8 -> 6
-				if(len != 6){ //if not 48 bit
-					goto out_invalid_option;
-				}
-				oall_seq = dccp_decode_value_var(value, len);
-				dccp_pr_debug("%s rx opt: MP_SEQ = %llu", dccp_role(sk), oall_seq);
 
-				opt_recv->dccpor_oall_seq = oall_seq;
-				break;
-			case DCCPO_MP_DELAY:
-				//TODO reordering
-				if(len != 4){ //if not 32 bit
-					goto out_invalid_option;
-				}
-				delay = dccp_decode_value_var(value, len);
-				dccp_pr_debug("%s rx opt: MP_DELAY = %u, sk %p dreq %p", dccp_role(sk), delay, sk, dreq);
-
-				opt_recv->dccpor_delay = delay;
-				break;
-			case DCCPO_MP_PATH_ID:
-				//TODO reordering
-				if(len != 4){ //if not 32 bit
-					goto out_invalid_option;
-				}
-				path_id = dccp_decode_value_var(value, len);
-				dccp_pr_debug("path_id = %u sk %p dreq %p", path_id, sk, dreq);
-				if(dreq->link_info == NULL)
-					dccp_pr_debug("link_info null");
-				dreq->id_rcv = path_id;
-				//dreq->link_info->id_rcv = path_id;
-				break;
-			case DCCPO_MP_DELPATH:
-				//TODO reordering
-				if(len != 4){ //if not 32 bit
-					goto out_invalid_option;
-				}
-				del_path = dccp_decode_value_var(value, len);
-				dccp_pr_debug("del_path = %u sk  %p skb %p", del_path, sk, skb);
-				opt_recv->dccpor_delpath_rcv = del_path;
-				//mpdccp_handle_rem_addr (del_path);
-				break;
+			case DCCPO_MP_CONFIRM:
+			case DCCPO_MP_JOIN:
+			case DCCPO_MP_FAST_CLOSE:
 			case DCCPO_MP_KEY:
 				if (len < 2) {
 					goto out_invalid_option;
@@ -379,7 +267,8 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 							goto out_invalid_option;
 						}
 
-						dccp_pr_debug("%s rx opt: DCCPO_MP_KEY(%d) = %llx, type %d, len %d, sk %p dreq %p remlen %d", dccp_role(sk), i, be64_to_cpu(*(u64*)value), key_type, key_len, sk, dreq, len);
+						dccp_pr_debug("%s rx opt: DCCPO_MP_KEY(%d) = %llx, type %d, len %d, sk %p dreq %p remlen %d",
+								dccp_role(sk), i, be64_to_cpu(*(u64*)value), key_type, key_len, sk, dreq, len);
 						memcpy(opt_recv->dccpor_mp_keys[i].value, value, key_len);
 						opt_recv->dccpor_mp_keys[i].size = key_len;
 						opt_recv->dccpor_mp_keys[i].type = key_type;
@@ -412,7 +301,8 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 							goto out_invalid_option;
 						}
 
-						dccp_pr_debug("%s rx opt: DCCPO_MP_KEY(%d) = %llx, type %d, len %d, sk %p dreq %p remlen %d", dccp_role(sk), i, be64_to_cpu(*(u64*)value), key_type, key_len, sk, dreq, len);
+						dccp_pr_debug("%s rx opt: DCCPO_MP_KEY(%d) = %llx, type %d, len %d, sk %p dreq %p remlen %d",
+								dccp_role(sk), i, be64_to_cpu(*(u64*)value), key_type, key_len, sk, dreq, len);
 						memcpy(opt_recv->dccpor_mp_keys[i].value, value, key_len);
 						opt_recv->dccpor_mp_keys[i].size = key_len;
 						opt_recv->dccpor_mp_keys[i].type = key_type;
@@ -426,17 +316,16 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 					}
 				}
 				break;
-			case DCCPO_MP_JOIN:
-				if (len != 8) {
+
+			case DCCPO_MP_SEQ:
+				//TODO reordering, use 48 bit > 8 -> 6
+				if(len != 6){ //if not 48 bit
 					goto out_invalid_option;
 				}
-				opt_recv->saw_mpjoin = 1;
-				opt_recv->dccpor_mp_token = get_unaligned_be32(value);
-				value += 4;
-				opt_recv->dccpor_mp_nonce = get_unaligned_be32(value);
-				dccp_pr_debug("%s rx opt: DCCPO_MP_JOIN = token %x nonce %x, sk %p dreq %p",
-								dccp_role(sk),opt_recv->dccpor_mp_token, opt_recv->dccpor_mp_nonce, sk, dreq);
+				opt_recv->dccpor_oall_seq = dccp_decode_value_var(value, len);
+				dccp_pr_debug("%s rx opt: MP_SEQ = %llu", dccp_role(sk), (u64)opt_recv->dccpor_oall_seq);
 				break;
+
 			case DCCPO_MP_HMAC:
 				if (len != MPDCCP_HMAC_SIZE) {
 					goto out_invalid_option;
@@ -448,33 +337,19 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 					dccp_send_ack(sk);
 				}
 				break;
+
+			case DCCPO_MP_RTT:
+			case DCCPO_MP_ADDADDR:
+			case DCCPO_MP_REMOVEADDR:
+			case DCCPO_MP_PRIO:
+			case DCCPO_MP_CLOSE:
+
 			default:
 				DCCP_CRIT("DCCP(%p): mp option %d(len=%d) not "
 					  "implemented, ignoring", sk, mp_opt, len);
 				break;
 			}
-// 		case DCCPO_ADD_ADDR:
-// 			/* This option can be of variable length depending on 
-// 			 * IPv4/6 and if a port is given. */
-// 			if(len == MPDCCP_LEN_ADD_ADDR4 || len == MPDCCP_LEN_ADD_ADDR4_PORT) {
-// 				mpdccp_handle_add_addr(value, sk, AF_INET);
-// #if IS_ENABLED(CONFIG_IPV6)
-// 			} else if(len == MPDCCP_LEN_ADD_ADDR6 || len == MPDCCP_LEN_ADD_ADDR6_PORT) {
-// 				/* Read IPv6 Address (128 bit). This is a little tricky, 
-// 				 * as __be128 does not exist */
-// 				mpdccp_handle_add_addr(value, sk, AF_INET6);
-// #endif /* CONFIG_IPV6 */
-// 			} else {
-// 				goto out_invalid_option;
-// 			}
-// 			break;
-// 		case DCCPO_DEL_ADDR:
-// 			if(len != MPDCCP_LEN_DEL_ADDR)
-// 				goto out_invalid_option;
 
-// 			mpdccp_handle_del_addr(value, sk, len);
-
-// 			break;
 #endif
 		case DCCPO_MIN_RX_CCID_SPECIFIC ... DCCPO_MAX_RX_CCID_SPECIFIC:
 			if (ccid_hc_rx_parse_options(dp->dccps_hc_rx_ccid, sk,
@@ -570,62 +445,6 @@ int dccp_insert_option(struct sk_buff *skb, const unsigned char option,
 }
 
 EXPORT_SYMBOL_GPL(dccp_insert_option);
-
-#if IS_ENABLED(CONFIG_IP_MPDCCP)
-static int dccp_insert_option_multipath(struct sk_buff *skb, const unsigned char mp_option,
-		       const void *value, const unsigned char len)
-{
-	unsigned char *to;
-
-	if (DCCP_SKB_CB(skb)->dccpd_opt_len + len + 3 > DCCP_MAX_OPT_LEN)
-		return -1;
-
-	DCCP_SKB_CB(skb)->dccpd_opt_len += len + 3;
-
-	to    = skb_push(skb, len + 3);
-	*to++ = DCCPO_MULTIPATH;
-	*to++ = len + 3;
-	*to++ = mp_option;
-
-	memcpy(to, value, len);
-	return 0;
-}
-
-/* Insert overall sequence number option */
-static int dccp_insert_option_mp_seq(struct sk_buff *skb, u64 *mp_oall_seq)
-{	
-	__be64 be_oall_seq;
-
-	be_oall_seq = cpu_to_be64((*mp_oall_seq << 16)); // convert to big endian // << 16
-	dccp_inc_seqno(mp_oall_seq); // increment overall sequence number
-	return dccp_insert_option_multipath(skb, DCCPO_MP_SEQ, &be_oall_seq, 6);
-}
-
-/* Insert delay option */
-static int dccp_insert_option_mp_delay(struct sk_buff *skb, u32 mp_delay)
-{	
-	__be32 be_mp_delay;
-	be_mp_delay = cpu_to_be32(mp_delay); // convert to big endian
-
-	return dccp_insert_option_multipath(skb, DCCPO_MP_DELAY, &be_mp_delay, sizeof(be_mp_delay));
-}
-
-static int dccp_insert_option_mp_path_id(struct sk_buff *skb, u32 mp_path_id)
-{	
-	__be32 be_mp_path_id;
-	be_mp_path_id = cpu_to_be32(mp_path_id); // convert to big endian
-
-	return dccp_insert_option_multipath(skb, DCCPO_MP_PATH_ID, &be_mp_path_id, sizeof(be_mp_path_id));
-}
-
-static int dccp_insert_option_mp_delpath(struct sk_buff *skb, u32 mp_delpath)
-{	
-	__be32 be_mp_delpath;
-	be_mp_delpath = cpu_to_be32(mp_delpath); // convert to big endian
-
-	return dccp_insert_option_multipath(skb, DCCPO_MP_DELPATH, &be_mp_delpath, sizeof(be_mp_delpath));
-}
-#endif
 
 static int dccp_insert_option_ndp(struct sock *sk, struct sk_buff *skb)
 {
@@ -865,6 +684,40 @@ static void dccp_insert_option_padding(struct sk_buff *skb)
 }
 
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
+static int dccp_insert_option_multipath(struct sk_buff *skb, const unsigned char mp_option,
+		       const void *value, const unsigned char len)
+{
+	unsigned char *to;
+
+	if (DCCP_SKB_CB(skb)->dccpd_opt_len + len + 3 > DCCP_MAX_OPT_LEN)
+		return -1;
+
+	DCCP_SKB_CB(skb)->dccpd_opt_len += len + 3;
+
+	to    = skb_push(skb, len + 3);
+	*to++ = DCCPO_MULTIPATH;
+	*to++ = len + 3;
+	*to++ = mp_option;
+
+	memcpy(to, value, len);
+	return 0;
+}
+
+/*static int dccp_insert_option_mp_confirm(struct sk_buff *skb)
+{
+	return 0;
+}
+
+static int dccp_insert_option_mp_join(struct sk_buff *skb)
+{
+	return 0;
+}
+
+static int dccp_insert_option_mp_fast_close(struct sk_buff *skb)
+{
+	return 0;
+}*/
+
 static int dccp_insert_option_mp_key(struct sk_buff *skb, struct mpdccp_cb *mpcb, struct dccp_request_sock *dreq)
 {
 	u8 buf[MPDCCP_MAX_KEYS*(MPDCCP_MAX_KEY_SIZE + 1)];
@@ -923,18 +776,46 @@ static int dccp_insert_option_mp_key(struct sk_buff *skb, struct mpdccp_cb *mpcb
 	}
 	return ret;
 }
-#endif
 
-#if IS_ENABLED(CONFIG_IP_MPDCCP)
-static int dccp_insert_option_mp_join(struct sk_buff *skb, u32 token, u32 nonce)
+/* Insert overall sequence number option */
+static int dccp_insert_option_mp_seq(struct sk_buff *skb, u64 *mp_oall_seq)
 {
-	u8 buf[8];
-
-	put_unaligned_be32(token, &buf[0]);
-	put_unaligned_be32(nonce, &buf[4]);
-
-	return dccp_insert_option_multipath(skb, DCCPO_MP_JOIN, &buf, sizeof(buf));
+	__be64 be_oall_seq;
+	be_oall_seq = cpu_to_be64((*mp_oall_seq << 16)); // convert to big endian // << 16
+	dccp_inc_seqno(mp_oall_seq); // increment overall sequence number
+	return dccp_insert_option_multipath(skb, DCCPO_MP_SEQ, &be_oall_seq, 6);
 }
+
+static int dccp_insert_option_mp_hmac(struct sk_buff *skb, u8 *hmac)
+{
+	return dccp_insert_option_multipath(skb, DCCPO_MP_HMAC, hmac, MPDCCP_HMAC_SIZE);
+}
+
+/*static int dccp_insert_option_mp_rtt(struct sk_buff *skb)
+{
+	return 0;
+}
+
+static int dccp_insert_option_mp_addaddr(struct sk_buff *skb)
+{
+	return 0;
+}
+
+static int dccp_insert_option_mp_removeaddr(struct sk_buff *skb)
+{
+	return 0;
+}
+
+static int dccp_insert_option_mp_prio(struct sk_buff *skb)
+{
+	return 0;
+}
+
+static int dccp_insert_option_mp_close(struct sk_buff *skb)
+{
+	return 0;
+}*/
+
 #endif
 
 
@@ -942,11 +823,6 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 {
 	struct dccp_sock *dp = dccp_sk(sk);
 	struct ccid2_hc_tx_sock *hc = NULL;
-#if IS_ENABLED(CONFIG_IP_MPDCCP)
-	struct tcp_info info;
-	u32 mp_path_id;
-	u32 mp_delpath;
-#endif
 	hc = ccid2_hc_tx_sk(sk);
 
 	DCCP_SKB_CB(skb)->dccpd_opt_len = 0;
@@ -982,15 +858,13 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 	    dccp_insert_option_timestamp_echo(dp, NULL, skb))
 		return -1;
 
-	/* Insert overall sequence number as DCCP option */
-	//dccp_insert_option_mp_seq(skb);
-
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 	/* Role dependent option required status. MPDCCP Server does not have 
 	 * to add delay values since MPDCCP Client knows delays due to its 
 	 * congestion control */
 	if (is_mpdccp(sk)) {
-		struct mpdccp_cb *mpcb = MPDCCP_CB(sk);
+		struct mpdccp_cb *mpcb = get_mpcb(sk);
+
 		/* Skip if fallback to sp DCCP */
 		if (mpcb && mpcb->fallback_sp)
 			goto out;
@@ -1000,23 +874,8 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 			case DCCP_PKT_DATA:
 			case DCCP_PKT_DATAACK:
 				dccp_insert_option_mp_seq(skb, &mpdccp_my_sock(sk)->mpcb->mp_oall_seqno);
-				//dccp_insert_option_mp_delay(skb, get_delay_val(hc)); // use MRTT as delay value
-				dccp_insert_option_mp_delay(skb, get_delay_valn(sk, &info));
-				dccp_pr_debug("delay = %u  on socket (0x%p)", get_delay_valn(sk, &info), sk); 
-				//dccp_pr_debug("delay = %u on socket (0x%p)", get_delay_val(hc), sk);
-				if(mpcb && mpcb->delpath){
-					mp_delpath = mpcb->delpath;
-					dccp_pr_debug("del_path %u", mp_delpath);
-					//printk(KERN_INFO "delpath sk %u, %p", mp_delpath, sk);
-					dccp_insert_option_mp_delpath(skb, mp_delpath);
-					mpdccp_my_sock(sk)->mpcb->delpath = 0;			
-				}
 				break;
 			case DCCP_PKT_REQUEST:
-				mp_path_id = mpdccp_my_sock(sk)->link_info->id;
-				dccp_pr_debug("path_id %u", mp_path_id);
-				dccp_insert_option_mp_path_id(skb, mp_path_id);
-
 				if (dccp_sk(sk)->is_kex_sk) {
 					dccp_pr_debug("(%s) REQ insert opt MP_KEY (supp)", dccp_role(sk));
 					/* Insert supported keys */
@@ -1042,7 +901,7 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 					if (!dccp_sk(sk)->auth_done){
 						/* Insert HMAC */
 						dccp_pr_debug("(%s) ACK insert opt MP_HMAC %llx", dccp_role(sk),be64_to_cpu(*((u64*)dccp_sk(sk)->mpdccp_loc_hmac)));
-						dccp_insert_option_multipath(skb, DCCPO_MP_HMAC, dccp_sk(sk)->mpdccp_loc_hmac, MPDCCP_HMAC_SIZE);
+						dccp_insert_option_mp_hmac(skb, dccp_sk(sk)->mpdccp_loc_hmac);
 					}
 				}
 			default:
@@ -1084,7 +943,7 @@ int dccp_insert_options_rsk_mp(const struct sock *sk, struct dccp_request_sock *
 	struct dccp_options_received *opt_recv = &dp->dccps_options_received;
 
 	if (opt_recv->saw_mpjoin) {
-		mpcb = MPDCCP_CB(dreq->meta_sk);
+		mpcb = get_mpcb(dreq->meta_sk);
 		if (!mpcb) {
 			dccp_pr_debug("(%s) invalid MPCB", dccp_role(sk));
 			return -1;
@@ -1094,7 +953,7 @@ int dccp_insert_options_rsk_mp(const struct sock *sk, struct dccp_request_sock *
 		dccp_insert_option_mp_join(skb, mpcb->mpdccp_loc_token, dreq->mpdccp_loc_nonce);
 		/* Insert HMAC */
 		dccp_pr_debug("(%s) RES insert opt MP_HMAC %llx", dccp_role(sk), be64_to_cpu(*((u64 *)dreq->mpdccp_loc_hmac)));
-		dccp_insert_option_multipath(skb, DCCPO_MP_HMAC, dreq->mpdccp_loc_hmac, MPDCCP_HMAC_SIZE);
+		dccp_insert_option_mp_hmac(skb, dreq->mpdccp_loc_hmac);
 	} else if (opt_recv->saw_mpkey) {
 		dccp_pr_debug("(%s) RES insert opt MP_KEY %llx", dccp_role(sk), be64_to_cpu(*((__be64 *)dreq->mpdccp_loc_key.value)));
 		/* Insert local key */

--- a/net/dccp/pm/pm_default.c
+++ b/net/dccp/pm/pm_default.c
@@ -66,9 +66,21 @@ struct mpdccp_local_addr {
 	sa_family_t family;
 	union inet_addr addr;
 	int if_idx;
-
+	u8 id;
 //	u8 next_v4_index;
 //	u8 next_v6_index;
+
+	struct rcu_head rcu;
+};
+
+struct mpdccp_remote_addr {
+	struct list_head address_list;
+
+	/* Address family, IPv4/v6 address, Interface ID */
+	sa_family_t family;
+	union inet_addr addr;
+	u16 port;
+	u8 id;
 
 	struct rcu_head rcu;
 };
@@ -104,6 +116,162 @@ static void mpdccp_announce_remove_path(int addr_id, struct mpdccp_cb *mpcb)
 }
 
 
+static int pm_get_remote_id(struct mpdccp_cb *mpcb, union inet_addr *addr, sa_family_t family)
+{
+	struct mpdccp_remote_addr *raddr;
+	struct list_head *pos, *temp;
+	rcu_read_lock();
+	list_for_each_safe(pos, temp, &mpcb->premote_list) {
+		raddr = list_entry(pos, struct mpdccp_remote_addr, address_list);
+		if(family == raddr->family){
+			if(family == AF_INET && addr->ip == raddr->addr.ip){
+				rcu_read_unlock();
+				return raddr->id;
+			}
+		}
+	}
+	rcu_read_unlock();
+	return -1;
+}
+
+/* Wipe the remote address list */
+static void pm_free_remote_addr_list(struct mpdccp_cb *mpcb)
+{
+	struct mpdccp_remote_addr *addr;
+	struct list_head *pos, *temp;
+	list_for_each_safe(pos, temp, &mpcb->premote_list) {
+		addr = list_entry(pos, struct mpdccp_remote_addr, address_list);
+		mpdccp_pr_debug("removing remote address %pI4", &addr->addr.ip);
+		list_del(pos);
+		kfree(addr);
+	}
+	mpcb->cnt_remote_addrs = 0;
+}
+
+/* handles newly learned remote address from MP_ADDADDR option */
+static void pm_add_remote_addr(struct mpdccp_cb *mpcb, sa_family_t family, u8 id, union inet_addr *addr, u16 port)
+{
+	struct mpdccp_remote_addr *remote_addr;
+	struct list_head *rlist = &mpcb->premote_list;
+
+	rcu_read_lock();
+	list_for_each_entry_rcu(remote_addr, rlist, address_list) {
+		if (family == remote_addr->family) {							//allows to have ipv6 and ipv4 with the same id in memory
+			if (id == remote_addr->id ||								//does the id exist?
+				(family == AF_INET  &&
+				remote_addr->addr.in.s_addr == addr->in.s_addr) ||		//does the ipv4 exist?
+				(family == AF_INET6 &&
+				ipv6_addr_equal(&remote_addr->addr.in6, &addr->in6)))	//does the ipv6 exist?
+			{
+				mpdccp_pr_debug("could not add remote address %pI4, id: %u", &addr->in.s_addr, id);
+				return;													// already exists
+			}
+		}
+	}
+
+	/*not in list add new entry*/
+	remote_addr = kzalloc(sizeof(*remote_addr), GFP_KERNEL);
+	remote_addr->family = family;
+	remote_addr->id = id;
+	remote_addr->port = port;
+
+	if (family == AF_INET) {
+		remote_addr->addr.in.s_addr = addr->in.s_addr;
+		mpdccp_pr_debug("Stored new remote IP %pI4:%u with id: %u", &addr->in, htons((unsigned)port), id);
+	} else {
+		remote_addr->addr.in6 = addr->in6;
+		mpdccp_pr_debug("Stored new remote IP %pI6:%u with id: %u", &addr->in6, htons((unsigned)port), id);
+	}
+	
+	list_add_tail_rcu(&remote_addr->address_list, &mpcb->premote_list);
+	mpcb->cnt_remote_addrs++;
+	rcu_read_unlock();
+	return;
+}
+
+/* closes all subflows with remote id == id_to_rm learned from MP_REMOVEADDR */
+static void pm_handle_rm_addr(u8 id_to_rm)
+{
+	struct sock *sk;
+	struct mpdccp_cb *mpcb;
+	struct mpdccp_remote_addr *remote_addr;
+
+	rcu_read_lock();
+	mpdccp_for_each_conn(pconnection_list, mpcb) {
+		list_for_each_entry_rcu(remote_addr, &mpcb->premote_list, address_list) {
+			if(remote_addr->id == id_to_rm){
+				list_del_rcu(&remote_addr->address_list);
+				kfree_rcu(remote_addr, rcu);
+				mpcb->cnt_remote_addrs--;
+				break;
+			}
+		}
+		mpdccp_for_each_sk(mpcb, sk) {
+			if(mpdccp_my_sock(sk)->remote_addr_id == id_to_rm){
+				/* when we receive MP_REMOVEADDR the subflow is already dead
+				mpdccp_close_subflow(mpcb, sk, 0);*/
+				dccp_close(sk, 0);
+				mpdccp_pr_debug("deleting path with id: %u sk %p", id_to_rm, sk);
+			}
+		}
+	}
+	rcu_read_unlock();
+}
+
+/* loops through plocal_addr_list and looks for matching address */
+static int mpdccp_find_address(struct mpdccp_pm_ns *pm_ns,
+				  sa_family_t family, const union inet_addr *addr, int if_idx, int *id)
+{
+	struct mpdccp_local_addr *local_addr;
+	struct list_head *pos, *temp;
+	int i = 0;
+
+	rcu_read_lock();
+	list_for_each_safe(pos, temp, &pm_ns->plocal_addr_list) {
+		i += 1;
+		local_addr = list_entry(pos, struct mpdccp_local_addr, address_list);
+		if (local_addr && family == local_addr->family &&
+					(!if_idx || if_idx == local_addr->if_idx) &&
+					local_addr->addr.in.s_addr == addr->in.s_addr) {
+			*id = local_addr->id;
+			rcu_read_unlock();
+			return i;
+		}
+	}
+	rcu_read_unlock();
+	return -1;
+}
+
+/* returns the address id belonging to the ip address + interface */
+static int pm_get_local_id(const struct sock *meta_sk,
+				  sa_family_t family, union inet_addr *addr, int if_idx)
+{
+	int index, id;
+	struct mpdccp_pm_ns *pm_ns = fm_get_ns(sock_net(meta_sk));
+
+	index = mpdccp_find_address(pm_ns, family, addr, if_idx, &id);
+	if (index != -1) {
+		mpdccp_pr_debug("get_local_id returned id: %u for %pI4", id, &addr->in.s_addr);
+		return id;
+	}
+	mpdccp_pr_debug("%s could not find address:%pI4 in memory.\n", __func__, &addr->in.s_addr);
+	return index;
+}
+
+/* Find the first free index in the bitfield */
+static int mpdccp_find_free_index(u8 bitfield)
+{
+	int i;
+	/* There are anyways no free bits... */
+	if (bitfield == 0xff) return -1;
+
+	i = ffs(~bitfield) - 1;
+	/* Try from 0 on */
+	if (i >= sizeof(bitfield) * 8)
+		return mpdccp_find_free_index(bitfield);
+	return i;
+}
+
 static int mpdccp_add_addr(struct mpdccp_pm_ns *pm_ns,
 			      			struct mpdccp_local_addr_event *event)
 {
@@ -117,7 +285,7 @@ static int mpdccp_add_addr(struct mpdccp_pm_ns *pm_ns,
 	sa_family_t family 			= event->family;
 	union inet_addr *addr 		= &event->addr;
     int if_idx 					= event->if_idx;
-	int locaddr_len;
+	int locaddr_len, loc_id;
 
 	struct list_head *plocal_addr_list = &pm_ns->plocal_addr_list;
 
@@ -158,16 +326,31 @@ static int mpdccp_add_addr(struct mpdccp_pm_ns *pm_ns,
     local_addr->family = family;
 	local_addr->if_idx = if_idx;
 
+	if (!pm_ns->loc4_bits) {
+		pm_ns->loc4_bits = 0;
+		mpdccp_pr_debug("Initiating loc4_bits.\n");
+	}
+
+	loc_id = mpdccp_find_free_index(pm_ns->loc4_bits);
+
+	if (loc_id < 0) {
+		mpdccp_pr_debug("Failed to find free address id index.\n");
+		return false;
+	}
+
+	local_addr->id = loc_id + 1;
+	pm_ns->loc4_bits |= (1 << loc_id);
+
 	if (family == AF_INET) {
 	    local_addr->addr.in.s_addr = addr->in.s_addr;
 
-		mpdccp_pr_debug("Updated IP %pI4 on ifidx %u\n",
-			    &addr->in.s_addr, if_idx);
+		mpdccp_pr_debug("updated IP %pI4 on ifidx %u, id: %u loc4: %u\n",
+			    &addr->in.s_addr, if_idx, local_addr->id, pm_ns->loc4_bits);
 	} else {
 		local_addr->addr.in6 = addr->in6;
 
-		mpdccp_pr_debug("%s updated IP %pI6 on ifidx %u\n",
-				__func__, &addr->in6, if_idx);
+		mpdccp_pr_debug("updated IP %pI6 on ifidx %u\n",
+				&addr->in6, if_idx);
 	}
 	
 	list_add_tail_rcu(&local_addr->address_list, plocal_addr_list);
@@ -261,6 +444,7 @@ static bool mpdccp_del_addr(struct mpdccp_pm_ns *pm_ns,
 				ipv6_addr_equal(&local_addr->addr.in6, &addr->in6)))
 			{
 				found = true;
+				addr_id = local_addr->id;
 				list_del_rcu(&local_addr->address_list);
 				kfree_rcu(local_addr, rcu);
 			}
@@ -274,6 +458,10 @@ static bool mpdccp_del_addr(struct mpdccp_pm_ns *pm_ns,
 		//rcu_read_unlock_bh();
 		return false;
 	}
+
+	mpdccp_pr_debug("loc4_bits %u removing id: %u\n", pm_ns->loc4_bits, addr_id);
+	pm_ns->loc4_bits &= ~(1 << (addr_id-1));
+	mpdccp_pr_debug("loc4_bits updated: %u\n", pm_ns->loc4_bits);
 
 	/* Iterate over all connections and remove any socket that still
 	 * uses this address */
@@ -302,8 +490,8 @@ static bool mpdccp_del_addr(struct mpdccp_pm_ns *pm_ns,
 						mpdccp_pr_debug("Deleting subflow socket %p with address %pI4.\n", sk, &sk->__sk_common.skc_rcv_saddr);
 					else
 						mpdccp_pr_debug("Deleting subflow socket %p with address %pI6.\n", sk, &sk->__sk_common.skc_v6_rcv_saddr);
-					//mpdccp_my_sock(sk)->mpcb->delpath = mpdccp_my_sock(sk)->link_info->id;
-					addr_id = mpdccp_my_sock(sk)->link_info->id;
+
+					addr_id = mpdccp_my_sock(sk)->local_addr_id;
 					mpdccp_close_subflow (mpcb, sk, 0);
 					mpdccp_announce_remove_path(addr_id, mpcb);
 
@@ -915,8 +1103,9 @@ add_init_client_conn (
 	struct sockaddr 		*local_address;
 	struct sockaddr_in 		local_v4_address;
 	struct sockaddr_in6 		local_v6_address;
+	union inet_addr rema;
 	int				locaddr_len;
-	int				ret=0, num=0;
+	int				ret=0, num=0, port=0;
 	struct mpdccp_pm_ns		*pm_ns;
 	int local_if_idx;
 	
@@ -928,6 +1117,17 @@ add_init_client_conn (
 	
 	memcpy(&mpcb->mpdccp_remote_addr, remote_address, socklen);
 	mpcb->remaddr_len = socklen;
+
+	if(remote_address->sa_family == AF_INET){
+		struct sockaddr_in *ad4 = (struct sockaddr_in*)remote_address;
+		rema.in = ad4->sin_addr;
+		port = ad4->sin_port;
+	} else if(remote_address->sa_family == AF_INET6) {
+		struct sockaddr_in6 *ad6 = (struct sockaddr_in6*)remote_address;
+		rema.in6 = ad6->sin6_addr;
+		port = ad6->sin6_port;
+	}
+	pm_add_remote_addr(mpcb, remote_address->sa_family, 0, &rema, port);
 	
 	/* Create subflows on all local interfaces */
 	//rcu_read_lock_bh();
@@ -1051,6 +1251,11 @@ add_init_server_conn (
 static struct mpdccp_pm_ops mpdccp_pm_default = {
 	.add_init_server_conn	= add_init_server_conn,
 	.add_init_client_conn	= add_init_client_conn,
+	.get_local_id		= pm_get_local_id,
+	.rm_remote_addr		= pm_handle_rm_addr,
+	.add_remote_addr = pm_add_remote_addr,
+	.get_remote_id = pm_get_remote_id,
+	.free_remote_addr = pm_free_remote_addr_list,
 	.name 			= "default",
 	.owner 			= THIS_MODULE,
 };


### PR DESCRIPTION
<h2> This update adds many new functionalities to handle address IDs. </h2>
<h3> Local address ID functions: </h3>
<dl>
  <dt>The path manager now assigns unique address ID values to each address stored in its plocal_addr_list
  <dd>- This happens on address events and is handled in mpdccp_add_addr and mpdccp_add_add() and mpdccp_del_addr() inside the path manager
  <dd>- Addresses and IDs are stored as mpdccp_local_addr in plocal_addr_list 
  <dt>New PM function that gets an address as input and returns the assigned ID
  <dd>- function get_local_id() is used as interface between an MPDCCP connection and the path manager
<dt>IDs get assigned to new subflows on initialization
<dd>- mpdccp_add_client_conn() and create_subflow() now also handle id assignment for client and server
<dd>- local_addr_id and remote_addr_id are now a part of the MPDCCP socket structure and store address IDs
<dt>Address IDs assigned by the path manager are never zero, thus we store the ID of our initial subflow in the connection memory at master_addr_id
<dd>- get_id(sk) is used to retrieve the ID belonging to a socket. The function will return zero sk == master_sk
</dl>
<h3> Remote address ID functions: </h3>
<dl>
  <dt>The path manager now stores remote address and ID information in a new premote_list
  <dt>New entries to premote_list are inserted by calling the path manager function add_remote_addr()
 <dd>- remote addresses are currently only added for the initial subflow
 <dd>- new remote addresses are also learned by mp_join and mp_addaddr (both not part of this pull request)
 <dt>pm_handle_rm_addr() is currently used to remove entries and will eventually be used by mp_removeaddr
 <dt>free_remote_addr_list() is used when closing the connection, to free memory
<dt>get_remote_id() will be used to assign remote addresses correctly on server side after a successful mp_join handshake
</dl>
