### PR TITLE
added new feature: mp_rtt option

### DIFF
--- a/include/linux/dccp.h
+++ b/include/linux/dccp.h
@@ -210,11 +210,10 @@ struct dccp_options_received {
 	u32	dccpor_elapsed_time;
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 	u64 dccpor_oall_seq:48;		/* MPDCCP overall sequence number */
-	u32 dccpor_delay;			/* MPDCCP delay transmission */
-	u32 dccpor_path_id;			/* MPDCCP delay transmission */
-#endif
-	u32 dccpor_delpath_rcv;
-#if IS_ENABLED(CONFIG_IP_MPDCCP)
+
+	u8 dccpor_rtt_type;         /* MP_RTT type */
+	u32 dccpor_rtt_value;
+	u32 dccpor_rtt_age;
 	u8 dccpor_mp_suppkeys;			/* MPDCCP supported key types */
 	u32 dccpor_mp_token;			/* MPDCCP path token */
 	u32 dccpor_mp_nonce;			/* MPDCCP path nonce */

--- a/net/dccp/ccid.c
+++ b/net/dccp/ccid.c
@@ -26,7 +26,7 @@ static struct ccid_operations *ccids[] = {
 #endif
 };
 
-u32 (*get_delay_valn)(struct sock *sk, struct tcp_info *info) = mrtt_as_delayn;
+u32 (*get_delay_valn)(struct sock *sk, struct tcp_info *info, u8 *type) = srtt_as_delayn;
 EXPORT_SYMBOL_GPL(get_delay_valn);
 
 static struct ccid_operations *ccid_by_number(const u8 id)

--- a/net/dccp/ccid.h
+++ b/net/dccp/ccid.h
@@ -272,27 +272,26 @@ static inline int ccid_hc_tx_getsockopt(struct ccid *ccid, struct sock *sk,
  * Obtain SRTT value form CCID2 TX sock.
  * NOTE: value is divided by 8 to match MRTT
  */
-static inline u32 srtt_as_delayn(struct sock *sk, struct tcp_info *info){
-    //dccp_pr_debug("srtt value : %u", info->tcpi_rtt);
+static inline u32 srtt_as_delayn(struct sock *sk, struct tcp_info *info, u8 *type){
     if(dccp_sk(sk)->dccps_hc_tx_ccid != NULL) { 
+		*type = 3;
     	ccid_hc_tx_get_info(dccp_sk(sk)->dccps_hc_tx_ccid, sk, info);
-    	return jiffies_to_msecs(info->tcpi_rtt >> 8); }
+    	return jiffies_to_msecs(info->tcpi_rtt >> 3); }		// divide by 2^3 (8)
     else { return 0; }
 }
 
 /**
  * Obtain MRTT value form CCID2 TX sock.
  */
-static inline u32 mrtt_as_delayn(struct sock *sk, struct tcp_info *info){
-    //dccp_pr_debug("mrtt value : %u", info->tcpi_rttvar);
-
+static inline u32 mrtt_as_delayn(struct sock *sk, struct tcp_info *info, u8 *type){
     if(dccp_sk(sk)->dccps_hc_tx_ccid != NULL) { 
+		*type = 0;
     	ccid_hc_tx_get_info(dccp_sk(sk)->dccps_hc_tx_ccid, sk, info);
     	return jiffies_to_msecs(info->tcpi_rttvar); }
     else{ return 0; }
 }
 
-extern u32 (*get_delay_valn)(struct sock *sk, struct tcp_info *info);
+extern u32 (*get_delay_valn)(struct sock *sk, struct tcp_info *info, u8 *type);
 
 static inline void set_srtt_as_delayn(void){
     get_delay_valn = srtt_as_delayn;

--- a/net/dccp/ccids/ccid2.c
+++ b/net/dccp/ccids/ccid2.c
@@ -379,6 +379,7 @@ static void ccid2_rtt_estimator(struct sock *sk, const long mrtt)
 	long m = mrtt ? : 1;
 
 	hc->tx_mrtt = mrtt;
+	hc->tx_last_ack_recv = ccid2_jiffies32;
 
 	if (hc->tx_srtt == 0) {
 		/* First measurement m */
@@ -799,7 +800,7 @@ static void ccid2_hc_tx_get_info(struct sock *sk, struct tcp_info *info)
 	info->tcpi_segs_out = ccid2_hc_tx_sk(sk)->tx_pipe;
 	info->tcpi_snd_cwnd = ccid2_hc_tx_sk(sk)->tx_cwnd;
 	info->tcpi_last_data_sent = ccid2_hc_tx_sk(sk)->tx_lsndtime;
-
+	info->tcpi_last_ack_recv = (ccid2_hc_tx_sk(sk)->tx_last_ack_recv > 0) ? ccid2_jiffies32 - ccid2_hc_tx_sk(sk)->tx_last_ack_recv : 0;
 }
 
 struct ccid_operations ccid2_ops = {

--- a/net/dccp/ccids/ccid2.h
+++ b/net/dccp/ccids/ccid2.h
@@ -83,7 +83,8 @@ struct ccid2_hc_tx_sock {
 				tx_mdev,
 				tx_mdev_max,
 				tx_rttvar,
-				tx_rto;
+				tx_rto,
+				tx_last_ack_recv;
 	u64			tx_rtt_seq:48;
 	struct timer_list	tx_rtotimer;
 

--- a/net/dccp/ccids/ccid5.c
+++ b/net/dccp/ccids/ccid5.c
@@ -352,6 +352,7 @@ static void ccid5_rtt_estimator(struct sock *sk, const long mrtt)
 	long m = mrtt ? : 1;
 
 	hc->tx_mrtt = mrtt;
+	hc->tx_last_ack_recv = ccid5_jiffies32;
 
 	if (hc->tx_srtt == 0) {
 		/* First measurement m */
@@ -1507,7 +1508,7 @@ static void ccid5_hc_tx_get_info(struct sock *sk, struct tcp_info *info)
 	info->tcpi_segs_out = ccid5_hc_tx_sk(sk)->tx_pipe;
 	info->tcpi_snd_cwnd = ccid5_hc_tx_sk(sk)->tx_cwnd;
 	info->tcpi_last_data_sent = ccid5_hc_tx_sk(sk)->tx_lsndtime;
-
+	info->tcpi_last_ack_recv = (ccid5_hc_tx_sk(sk)->tx_last_ack_recv > 0) ? ccid5_jiffies32 - ccid5_hc_tx_sk(sk)->tx_last_ack_recv : 0;
 }
 
 struct ccid_operations ccid5_ops = {

--- a/net/dccp/ccids/ccid5.h
+++ b/net/dccp/ccids/ccid5.h
@@ -79,7 +79,8 @@ struct ccid5_hc_tx_sock {
 				tx_mdev,
 				tx_mdev_max,
 				tx_rttvar,
-				tx_rto;
+				tx_rto,
+				tx_last_ack_recv;
 	u64			tx_rtt_seq:48;
 	struct timer_list	tx_rtotimer;
 

--- a/net/dccp/mpdccp_reordering.c
+++ b/net/dccp/mpdccp_reordering.c
@@ -328,7 +328,7 @@ struct rcv_buff *mpdccp_init_rcv_buff(struct sock *sk, struct sk_buff *skb, stru
 	dsk = dccp_sk(sk);
 	rb->oall_seqno = (u64)dsk->dccps_options_received.dccpor_oall_seq;
 	//mpdccp_pr_debug("seqno %lu sk %p", (unsigned long)rb->oall_seqno, sk);
-	rb->latency = (u32)dsk->dccps_options_received.dccpor_delay;
+	rb->latency = (u32)dsk->dccps_options_received.dccpor_rtt_value;	/* need to divide by two for one way delay*/
 	//mpdccp_pr_debug("delay %lu sk %p", (unsigned long)rb->latency, sk);
 	return rb;
 }


### PR DESCRIPTION
<h2> This commit adds the MP_RTT option (#9) </h2>

SRTT (RTT type 3) and raw RTT (rtt type 0) are supported. 
RTT age is also supported. RTT age specifies the time since the last RTT computation / last received ACK 

Currently, it is configured to send an MP_RTT with every second DATAACK packet.
Type is set to SRTT.

This option should be extended with an interface that allows on-the-fly changing of the RTT type.
