### PR TITLE
Mp join support for Address ID

### DIFF
--- a/include/linux/dccp.h
+++ b/include/linux/dccp.h
@@ -208,6 +208,12 @@ struct dccp_options_received {
 	u32	dccpor_elapsed_time;
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 	u64 dccpor_oall_seq:48;		/* MPDCCP overall sequence number */
+	
+	u32 dccpor_join_ip_local;     /* MPDCCP mp_join received local ip */
+	u32 dccpor_join_ip_remote;     /* MPDCCP mp_join received remote ip */
+	u8 dccpor_join_id;          /* MPDCCP mp_join received address id */
+	u16 dccpor_join_port;
+
 	u8 dccpor_mp_suppkeys;			/* MPDCCP supported key types */
 	u32 dccpor_mp_token;			/* MPDCCP path token */
 	u32 dccpor_mp_nonce;			/* MPDCCP path nonce */

--- a/net/dccp/mpdccp_proto.c
+++ b/net/dccp/mpdccp_proto.c
@@ -944,14 +944,17 @@ static int _mpdccp_check_req(struct sock *sk, struct sock *newsk, struct request
 		if(mpcb->pm_ops->get_local_id && mpcb->pm_ops->get_remote_id){
 			addr.ip = ip_hdr(skb)->daddr;
 			loc_id = mpcb->pm_ops->get_local_id(mpcb->meta_sk, AF_INET, &addr, 0);
-			if(loc_id < 0){
+			addr.ip = ip_hdr(skb)->saddr;
+			rem_id = mpcb->pm_ops->get_remote_id(mpcb, &addr, AF_INET);
+
+			if(loc_id < 0 || rem_id < 0){
 				mpdccp_pr_debug("cant create subflow with unknown address id");
 				return -1;
 			}
 		}
 		/* Now add the subflow to the mpcb */
 
-		ret = create_subflow(newsk, meta_sk, skb, req, 0, (u8)loc_id, 0);//_mpdccp_listen(newsk, 1);
+		ret = create_subflow(newsk, meta_sk, skb, req, 0, (u8)loc_id, (u8)rem_id);
 		if (ret) {
 			mpdccp_pr_debug("error mpdccp_create_master_sub %d", ret);
 			return -1;


### PR DESCRIPTION
<h2> This pull request extends on pull request #11 and further adds support for the address ID field in MP_JOIN </h2>

New addresses and ids learned from MP_JOIN are now stored using add_remote_addr().
If the MP_JOIN handshake is completed we then use get_remote_id() to retrieve the id again and assign it to our new subflow.