### PR TITLE
new feature: MP_PRIO

### DIFF
--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -257,6 +257,8 @@ struct mpdccp_cb {
 	int                     remaddr_len;	// length of mpdccp_remote_addr;
 	u16			    server_port;	// Server only 
 	int			    backlog;
+	u8			announce_prio[3];				// id, prio, flag for send
+
 	int			up_reported;
 	u8 			master_addr_id;
 	int  		cnt_remote_addrs;
@@ -386,6 +388,10 @@ int my_sock_init (struct sock *sk, struct mpdccp_cb *mpcb, int if_idx, enum mpdc
 void my_sock_destruct (struct sock *sk);
 /* the real xmit */
 int mpdccp_xmit_to_sk (struct sock *sk, struct sk_buff *skb);
+
+void mpdccp_init_announce_prio(struct sock *sk);
+int mpdccp_get_prio(struct sock *sk);
+int mpdccp_set_prio(struct sock *sk, int prio);
 
 /* Functions for authentication */
 int mpdccp_hash_key(const u8 *in, u8 inlen, u32 *token);

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -1161,6 +1161,47 @@ out:
     return;
 }
 
+int mpdccp_set_prio(struct sock *sk, int prio)
+{
+   struct mpdccp_link_info      *link;
+
+   /* copy and get link */
+   link = mpdccp_ctrl_getcpylink (sk);
+   if (!link) return -EINVAL;
+   /* change prio */
+   mpdccp_link_change_mpdccp_prio (link, prio);
+   /* release link */
+   mpdccp_link_put (link);
+   return 0;
+}
+EXPORT_SYMBOL(mpdccp_set_prio);
+
+int mpdccp_get_prio(struct sock *sk)
+{
+	struct mpdccp_link_info *link;
+	int prio;
+
+	link = mpdccp_ctrl_getlink (sk);
+	if (!link)
+		return -EINVAL;
+	prio = link->mpdccp_prio;
+	mpdccp_link_put (link);
+	return prio;
+}
+EXPORT_SYMBOL(mpdccp_get_prio);
+
+void mpdccp_init_announce_prio(struct sock *sk)
+{
+    struct my_sock   *my_sk = mpdccp_my_sock(sk);
+    struct mpdccp_cb *mpcb = my_sk->mpcb;
+
+    mpcb->announce_prio[0] = get_id(sk);
+    mpcb->announce_prio[1] = mpdccp_get_prio(sk);
+    mpcb->announce_prio[2] = 1;
+    dccp_send_keepalive(sk);
+}
+EXPORT_SYMBOL(mpdccp_init_announce_prio);
+
 int mpdccp_hash_key(const u8 *key, u8 keylen, u32 *token)
 {
         SHASH_DESC_ON_STACK(desc, tfm_hash);

--- a/net/dccp/mpdccp_link.c
+++ b/net/dccp/mpdccp_link.c
@@ -688,6 +688,7 @@ mpdccp_link_add (
 		strcpy (link->ndev_name, MPDCCP_LINK_TO_DEV(link)->name);
 	}
 	link->id = link_get_next_counter (net);
+	link->mpdccp_prio = 3;
 	ret = mpdccp_link_sysfs_add (link);
 	if (ret < 0) {
 		mpdccp_pr_error ("mpdccp_link_add(): error adding sysfs entry\n");

--- a/net/dccp/mpdccp_pm.h
+++ b/net/dccp/mpdccp_pm.h
@@ -73,6 +73,7 @@ struct mpdccp_pm_ops {
 	void		(*add_remote_addr)      (struct mpdccp_cb*, sa_family_t, u8, union inet_addr*, u16);
 	int			(*get_remote_id)		(struct mpdccp_cb*, union inet_addr*, sa_family_t);
 	void		(*free_remote_addr)     (struct mpdccp_cb*);
+	void 		(*handle_rcv_prio)		(struct mpdccp_cb*, u8, u8);
 	
 	char			name[MPDCCP_PM_NAME_MAX];
 	struct module		*owner;

--- a/net/dccp/mpdccp_proto.c
+++ b/net/dccp/mpdccp_proto.c
@@ -639,6 +639,9 @@ static int _mpdccp_rcv_respond_partopen_state_process(struct sock *sk, int type)
 			WARN_ON(sk->sk_send_head == NULL);
 			kfree_skb(sk->sk_send_head);
 			sk->sk_send_head = NULL;
+
+			if(mpdccp_get_prio(sk) != 3)				// dont announce if prio = 3 (default value)
+				mpdccp_init_announce_prio(sk);			// announce prio values for all subflows after creation
 		}
 
 		/* Authentication complete, send an additional ACK if required */

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -343,6 +343,21 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 			case DCCPO_MP_ADDADDR:
 			case DCCPO_MP_REMOVEADDR:
 			case DCCPO_MP_PRIO:
+				if (len == 2) {
+					u8 id = dccp_decode_value_var(value, 1);
+					u8 prio = dccp_decode_value_var(value+1, 1);
+					dccp_pr_debug("%s rx opt: DCCPO_MP_PRIO = value: %d id: %d", dccp_role(sk), prio, id);
+
+					if(prio < 16 && is_mpdccp(sk)){
+						struct mpdccp_cb *mpcb = get_mpcb(sk);
+
+						if (mpcb->pm_ops->handle_rcv_prio)
+							mpcb->pm_ops->handle_rcv_prio(mpcb, prio, id);
+					}
+				} else
+					goto out_invalid_option;
+				break;
+
 			case DCCPO_MP_CLOSE:
 
 			default:
@@ -805,13 +820,14 @@ static int dccp_insert_option_mp_addaddr(struct sk_buff *skb)
 static int dccp_insert_option_mp_removeaddr(struct sk_buff *skb)
 {
 	return 0;
-}
+}*/
 
-static int dccp_insert_option_mp_prio(struct sk_buff *skb)
+static int dccp_insert_option_mp_prio(struct sk_buff *skb, u8 *buf, struct mpdccp_cb *mpcb, u8 id)
 {
-	return 0;
+	return dccp_insert_option_multipath(skb, DCCPO_MP_PRIO, buf, 2);
 }
 
+/*
 static int dccp_insert_option_mp_close(struct sk_buff *skb)
 {
 	return 0;
@@ -865,6 +881,7 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 	 * congestion control */
 	if (is_mpdccp(sk)) {
 		struct mpdccp_cb *mpcb = get_mpcb(sk);
+		u8 mp_addr_id = get_id(sk);
 
 		/* Skip if fallback to sp DCCP */
 		if (mpcb && mpcb->fallback_sp)
@@ -874,7 +891,18 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 		switch(DCCP_SKB_CB(skb)->dccpd_type){
 			case DCCP_PKT_DATA:
 			case DCCP_PKT_DATAACK:
+			case DCCP_PKT_DATA:
 				dccp_insert_option_mp_seq(skb, &mpdccp_my_sock(sk)->mpcb->mp_oall_seqno);
+				if(mpcb){
+
+					if(mpcb->announce_prio[2]){
+						dccp_pr_debug("(%s) REQ insert opt MP_PRIO, addr_id: %u prio: %u",
+								dccp_role(sk), mpcb->announce_prio[0], mpcb->announce_prio[1]);
+
+						dccp_insert_option_mp_prio(skb, mpcb->announce_prio, mpcb, mp_addr_id);
+						mpcb->announce_prio[2] = 0;
+					}
+				}
 				break;
 			case DCCP_PKT_REQUEST:
 				if (dccp_sk(sk)->is_kex_sk) {


### PR DESCRIPTION
<h3> This pull request extends #11 and adds support for MP_PRIO (issue #3) </h2>

MP_PRIO options are sent right after a subflow was initialized to advertise its priority
Currently, it is configured to only send an MP_PRIO option if the priority value differs from the default (!=3)
- to send a prio option mpdccp_init_announce_prio(sk) is called.
- this will immediately send a zero-size DATA packet with the option attached 

MP_PRIO options are also sent after a manual change to /sys/module/mpdccplink/links/dev/[my_interface]/mpdccp_prio
- update events are registered by a mpdccplink notifier chain and handled in pm_handle_link_event()

Received PRIO values are parsed and handled by the new handle_rcv_prio() function in the path manager.
- this function will create a copy of the mpdccplink info structure with the new prio value

currently, there is still a bug, that copies of the info structure are not removed after the connection was closed.
This is most likely because this GitHub repo has an outdated mpdccplink version and should be fixed with an update.


