### PR TITLE
New features: MP_ADDADDR and MP_REMOVEADDR

### DIFF
--- a/include/linux/dccp.h
+++ b/include/linux/dccp.h
@@ -208,6 +208,9 @@ struct dccp_options_received {
 	u32	dccpor_elapsed_time;
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 	u64 dccpor_oall_seq:48;		/* MPDCCP overall sequence number */
+	u8 dccpor_addaddr[MPDCCP_ADDADDR_SIZE];
+	u8 dccpor_addaddr_len;
+	u8 dccpor_removeaddr[4];
 	u8 dccpor_mp_suppkeys;			/* MPDCCP supported key types */
 	u32 dccpor_mp_token;			/* MPDCCP path token */
 	u32 dccpor_mp_nonce;			/* MPDCCP path nonce */

--- a/include/uapi/linux/dccp.h
+++ b/include/uapi/linux/dccp.h
@@ -184,8 +184,8 @@ enum {
 	DCCPO_MP_SEQ = 4,						/* MPDCCP overall sequence number */
 	DCCPO_MP_HMAC = 5,					/* HMA Code for authentication */
 	DCCPO_MP_RTT = 6,						/* Transmit RTT values */
-	DCCPO_MP_ADDADDR = 7,				/* (unused): Option for adding an address from behind a firewall */
-	DCCPO_MP_REMOVEADDR = 8,				/* (unused): Option for deleting an address from behind a firewall */
+	DCCPO_MP_ADDADDR = 7,				/* Advertise additional Address */
+	DCCPO_MP_REMOVEADDR  = 8,			/* Remove Address */
 	DCCPO_MP_PRIO = 9,					/* path priorization */
 	DCCPO_MP_CLOSE = 10,				/* Close MPDCCP flow */
 };
@@ -248,6 +248,8 @@ enum dccp_packet_dequeueing_policy {
 #define MPDCCP_MAX_KEY_SIZE MPDCCP_C25519_KEY_SIZE
 #define MPDCCP_MAX_KEYS 3
 #define MPDCCP_HMAC_SIZE 20
+
+#define MPDCCP_ADDADDR_SIZE 22
 
 /* MPDCCP version type */
 enum mpdccp_version {

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -257,6 +257,11 @@ struct mpdccp_cb {
 	int                     remaddr_len;	// length of mpdccp_remote_addr;
 	u16			    server_port;	// Server only 
 	int			    backlog;
+	u8              delpath_id;
+	u8			    addpath_id;
+	sa_family_t		addpath_family;
+	union inet_addr	addpath_addr;
+	u16			addpath_port;
 	int			up_reported;
 	u8 			master_addr_id;
 	int  		cnt_remote_addrs;
@@ -361,8 +366,7 @@ int mpdccp_report_alldown (struct sock*);
 int mpdccp_add_client_conn (struct mpdccp_cb *, struct sockaddr *local, int llen, int if_idx, struct sockaddr *rem, int rlen);
 int mpdccp_add_listen_sock (struct mpdccp_cb *, struct sockaddr *local, int llen, int if_idx);
 int mpdccp_close_subflow (struct mpdccp_cb*, struct sock*, int destroy);
-void mpdccp_handle_rem_addr (u32 del_path);
-struct sock *mpdccp_select_ann_sock(struct mpdccp_cb *mpcb);
+struct sock *mpdccp_select_ann_sock(struct mpdccp_cb *mpcb, u8 id);
 
 struct mpdccp_cb *mpdccp_alloc_mpcb(void);
 

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -964,16 +964,15 @@ EXPORT_SYMBOL (mpdccp_handle_rem_addr);
 
 /*select sk to announce data*/
 
-struct sock *mpdccp_select_ann_sock(struct mpdccp_cb *mpcb)
+struct sock *mpdccp_select_ann_sock(struct mpdccp_cb *mpcb, u8 id)
 {
 
     struct sock *sk, *avsk = NULL;
-    /*returns the first avilable socket - can be improved to 
+    /*returns the first avilable socket that is not id - can be improved to 
      *the latest used or lowest rtt as in mptcp mptcp_select_ack_sock */
 
     mpdccp_for_each_sk(mpcb, sk) {
-
-        if (!mpdccp_sk_can_send(sk))
+        if (!mpdccp_sk_can_send(sk) || mpdccp_my_sock(sk)->local_addr_id == id)
             continue;
         avsk = sk;
         goto avfound;

--- a/net/dccp/mpdccp_pm.h
+++ b/net/dccp/mpdccp_pm.h
@@ -73,6 +73,7 @@ struct mpdccp_pm_ops {
 	void		(*add_remote_addr)      (struct mpdccp_cb*, sa_family_t, u8, union inet_addr*, u16);
 	int			(*get_remote_id)		(struct mpdccp_cb*, union inet_addr*, sa_family_t);
 	void		(*free_remote_addr)     (struct mpdccp_cb*);
+	int 		(*pm_hmac)				(struct mpdccp_cb*, u8, sa_family_t, union inet_addr*, u16, bool, u8*);
 	
 	char			name[MPDCCP_PM_NAME_MAX];
 	struct module		*owner;

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -51,6 +51,67 @@ u64 dccp_decode_value_var(const u8 *bf, const u8 len)
 	return value;
 }
 
+
+void mpdccp_do_hmac_chk(struct sock *sk, struct dccp_options_received *opt_recv){
+	struct mpdccp_cb *mpcb = get_mpcb(sk);
+	u8 chk_hmac[MPDCCP_HMAC_SIZE];
+	int ret;
+
+	if (opt_recv->dccpor_addaddr[0] && mpcb->pm_ops->add_remote_addr){
+		u8 len = opt_recv->dccpor_addaddr_len;
+		u8 id = opt_recv->dccpor_addaddr[3];
+		union inet_addr addr;
+		sa_family_t family = AF_INET;
+		u16 port = 0;
+
+		if(len == 8 || len == 10){					// ipv4
+			addr.ip = get_unaligned_be32(&opt_recv->dccpor_addaddr[4]);
+			if(len == 10){
+				port = get_unaligned_be16(&opt_recv->dccpor_addaddr[8]);
+			}
+			dccp_pr_debug("rx opt: DCCPO_MP_ADDADDR = rem_id: %u, ip4 %pI4:%u", id, &addr.ip, port);
+		} else if(len == 20 || len == 22){			//ipv6
+			family = AF_INET6;
+			memcpy(addr.ip6, &opt_recv->dccpor_addaddr[4], 16);
+			if(len == 22){
+				port = get_unaligned_be16(&opt_recv->dccpor_addaddr[20]);
+			}
+			dccp_pr_debug("rx opt: DCCPO_MP_ADDADDR = rem_id: %u, ip6 %pI6:%u", id, &addr.ip6, port);
+		}
+
+		ret = mpcb->pm_ops->pm_hmac(mpcb, id, family, &addr, port, 0, chk_hmac);
+
+		if(!ret){
+			dccp_pr_debug("HMAC compare rx: %llx exp: %llx", be64_to_cpu(*(u64 *)opt_recv->dccpor_mp_hmac),
+					be64_to_cpu(*((u64 *)chk_hmac)));
+			if(memcmp(opt_recv->dccpor_mp_hmac, chk_hmac, MPDCCP_HMAC_SIZE)){
+				dccp_pr_debug("HMAC CHECK FAILED!");
+				return;
+			}
+			mpcb->pm_ops->add_remote_addr(mpcb, family, id, &addr, port);
+
+		}
+	}
+	
+	else if(opt_recv->dccpor_removeaddr[0] && mpcb->pm_ops->rm_remote_addr){
+		u8 id = opt_recv->dccpor_removeaddr[3];
+		dccp_pr_debug("%s rx opt: DCCPO_MP_REMOVEADDR id: %u", dccp_role(sk), id);
+
+		ret = mpcb->pm_ops->pm_hmac(mpcb, id, 0, 0, 0, 0, chk_hmac);
+
+		if(!ret){
+			dccp_pr_debug("HMAC compare rx: %llx exp: %llx", be64_to_cpu(*(u64 *)opt_recv->dccpor_mp_hmac),
+					be64_to_cpu(*((u64 *)chk_hmac)));
+			if(memcmp(opt_recv->dccpor_mp_hmac, chk_hmac, MPDCCP_HMAC_SIZE)){
+				dccp_pr_debug("HMAC CHECK FAILED!");
+				return;
+			}
+			mpcb->pm_ops->rm_remote_addr(id);
+
+		}
+	}
+}
+
 /**
  * dccp_parse_options  -  Parse DCCP options present in @skb
  * @sk: client|server|listening dccp socket (when @dreq != NULL)
@@ -331,17 +392,34 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 				if (len != MPDCCP_HMAC_SIZE) {
 					goto out_invalid_option;
 				}
-				dccp_pr_debug("%s rx opt: DCCPO_MP_HMAC = %llx, sk %p dreq %p", dccp_role(sk), be64_to_cpu(*(u64 *)value), sk, dreq);
-				memcpy(opt_recv->dccpor_mp_hmac,value, MPDCCP_HMAC_SIZE);
+				dccp_pr_debug("%s rx opt: DCCPO_MP_HMAC = %llx, sk %p dreq %p", dccp_role(sk),
+						be64_to_cpu(*(u64 *)value), sk, dreq);
+
+				memcpy(opt_recv->dccpor_mp_hmac, value, MPDCCP_HMAC_SIZE);
 				/* Send ack if the authentication was completed before */
-				if ((pkt_type == DCCP_PKT_ACK) && dccp_sk(sk)->auth_done) {
+				if ((pkt_type == DCCP_PKT_ACK) && dccp_sk(sk)->auth_done)
 					dccp_send_ack(sk);
-				}
+
+				if(is_mpdccp(sk))
+					mpdccp_do_hmac_chk(sk, opt_recv);
 				break;
 
 			case DCCPO_MP_RTT:
 			case DCCPO_MP_ADDADDR:
+				if(len == 5 || len == 7 || len == 17 || len == 19){
+					opt_recv->dccpor_addaddr_len = len+3;
+					memcpy(&opt_recv->dccpor_addaddr[0], value-3, opt_recv->dccpor_addaddr_len);
+				} else
+					goto out_invalid_option;
+				break;
+
 			case DCCPO_MP_REMOVEADDR:
+				if(len == 1){
+					memcpy(&opt_recv->dccpor_removeaddr[0], value-3, len+3);
+				} else
+					goto out_invalid_option;
+				break;
+
 			case DCCPO_MP_PRIO:
 			case DCCPO_MP_CLOSE:
 
@@ -794,19 +872,35 @@ static int dccp_insert_option_mp_hmac(struct sk_buff *skb, u8 *hmac)
 
 /*static int dccp_insert_option_mp_rtt(struct sk_buff *skb)
 {
-	return 0;
-}
+}*/
 
-static int dccp_insert_option_mp_addaddr(struct sk_buff *skb)
+static int dccp_insert_option_mp_addaddr(struct sk_buff *skb, struct mpdccp_cb *mpcb)
 {
-	return 0;
+	u8 buf[MPDCCP_ADDADDR_SIZE];
+	int len = 0;
+
+	buf[len] = mpcb->addpath_id;
+	len++;
+	if(mpcb->addpath_family == AF_INET){
+		put_unaligned_be32(mpcb->addpath_addr.ip, &buf[len]);
+		len += 4;
+	} else if(mpcb->addpath_family == AF_INET6){
+		memcpy(&buf[len], mpcb->addpath_addr.ip6, 16);
+		len += 16;
+	}
+
+	if(mpcb->addpath_port){
+		put_unaligned_be16(mpcb->addpath_port, &buf[len]);
+		len += 2;
+	}
+	return dccp_insert_option_multipath(skb, DCCPO_MP_ADDADDR, &buf, len);
 }
 
-static int dccp_insert_option_mp_removeaddr(struct sk_buff *skb)
+static int dccp_insert_option_mp_removeaddr(struct sk_buff *skb, u8 id)
 {
-	return 0;
+	return dccp_insert_option_multipath(skb, DCCPO_MP_REMOVEADDR, &id, 1);
 }
-
+/*
 static int dccp_insert_option_mp_prio(struct sk_buff *skb)
 {
 	return 0;
@@ -865,6 +959,7 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 	 * congestion control */
 	if (is_mpdccp(sk)) {
 		struct mpdccp_cb *mpcb = get_mpcb(sk);
+		u8 mp_addr_id = get_id(sk);
 
 		/* Skip if fallback to sp DCCP */
 		if (mpcb && mpcb->fallback_sp)
@@ -874,7 +969,37 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 		switch(DCCP_SKB_CB(skb)->dccpd_type){
 			case DCCP_PKT_DATA:
 			case DCCP_PKT_DATAACK:
+			case DCCP_PKT_DATA:
 				dccp_insert_option_mp_seq(skb, &mpdccp_my_sock(sk)->mpcb->mp_oall_seqno);
+				if(mpcb){
+					if(mpcb->delpath_id && mpcb->pm_ops){
+						u8 del_id = chk_id(mpcb->delpath_id, mpcb->master_addr_id);
+						/* dont send over path that is about to be removed */
+						if(del_id != mp_addr_id){
+							u8 delpath_hmac[MPDCCP_HMAC_SIZE];
+							mpcb->pm_ops->pm_hmac(mpcb, del_id, 0, 0, 0, 1, delpath_hmac);
+							dccp_pr_debug("(%s) REQ insert opt MP_HMAC %llx", dccp_role(sk), be64_to_cpu(*((u64 *)delpath_hmac)));
+							dccp_insert_option_mp_hmac(skb, delpath_hmac);
+
+							dccp_pr_debug("(%s) REQ insert opt MP_REMOVEADDR, id: %u", dccp_role(sk), del_id);
+							dccp_insert_option_mp_removeaddr(skb, del_id);
+							mpcb->delpath_id = 0;
+						}
+					}
+
+					if(mpcb->addpath_id && mpcb->pm_ops){
+						u8 addpath_hmac[MPDCCP_HMAC_SIZE];
+						mpcb->pm_ops->pm_hmac(mpcb, mpcb->addpath_id, AF_INET, &mpcb->addpath_addr, mpcb->addpath_port, 1, addpath_hmac);
+						dccp_pr_debug("(%s) REQ insert opt MP_HMAC %llx", dccp_role(sk), be64_to_cpu(*((u64 *)addpath_hmac)));
+						dccp_insert_option_mp_hmac(skb, addpath_hmac);
+
+						dccp_pr_debug("(%s) REQ insert opt MP_ADDADDR, id: %u, ip: %pI4", dccp_role(sk), mpcb->addpath_id, &mpcb->addpath_addr.ip);
+						dccp_insert_option_mp_addaddr(skb, mpcb);
+						mpcb->addpath_id = 0;
+						mpcb->addpath_port = 0;
+					}
+
+				}
 				break;
 			case DCCP_PKT_REQUEST:
 				if (dccp_sk(sk)->is_kex_sk) {

--- a/net/dccp/pm/pm_default.c
+++ b/net/dccp/pm/pm_default.c
@@ -32,6 +32,7 @@
 #include <net/addrconf.h>
 #include <net/net_namespace.h>
 #include <net/netns/mpdccp.h>
+#include <asm/unaligned.h>
 
 #include "../ccids/ccid2.h"
 #include "../dccp.h"
@@ -103,16 +104,49 @@ static struct mpdccp_pm_ns *fm_get_ns(const struct net *net)
  * existing connections. We assume that every operation produces a 
  * consistent state upon completion, i.e. if an address is not
  * in the list, it is not used in any connection. */
-static void mpdccp_announce_remove_path(int addr_id, struct mpdccp_cb *mpcb)
+static void mpdccp_send_remove_path(u8 addr_id, struct mpdccp_cb *mpcb)
 {
-	struct sock *sk = mpdccp_select_ann_sock(mpcb);
+	struct sock *sk = mpdccp_select_ann_sock(mpcb, addr_id);
 	if (sk){
-		mpcb->delpath = addr_id;
-		mpdccp_pr_debug("Sending delete path\n");
-#if IS_ENABLED(CONFIG_DCCP_KEEPALIVE)
+		mpcb->delpath_id = addr_id;
 		dccp_send_keepalive(sk);
-#endif
 	}
+}
+
+static void mpdccp_send_add_path(struct mpdccp_local_addr *loc_addr, u16 port, struct mpdccp_cb *mpcb)
+{
+	struct sock *sk = mpdccp_select_ann_sock(mpcb, 0);
+	if (sk){
+		mpcb->addpath_id = loc_addr->id;
+		mpcb->addpath_family = loc_addr->family;
+		memcpy(mpcb->addpath_addr.all, loc_addr->addr.all, 4);
+		mpcb->addpath_port = port;
+		dccp_send_keepalive(sk);
+	}
+}
+
+static int pm_get_addr_hmac(struct mpdccp_cb *mpcb,
+							u8 id, sa_family_t family,
+							union inet_addr *addr, u16 port,
+							bool send, u8 *hmac)
+{
+	u8 msg[19];		//1:id + 16:ipv6 + 2:port
+	int len = 1;
+	msg[0] = id;
+
+	if(family == AF_INET){
+		put_unaligned_be32(addr->ip, &msg[1]);
+		put_unaligned_be16(port, &msg[5]);
+		len = 7;
+	} else if(family == AF_INET6){
+		memcpy(&msg[1], addr->ip6, 16);
+		put_unaligned_be16(port, &msg[17]);
+		len = 19;
+	}
+	if((send && mpcb->role == MPDCCP_CLIENT) || (!send && mpcb->role != MPDCCP_CLIENT))
+		return mpdccp_hmac_sha256(mpcb->dkeyA, mpcb->dkeylen, msg, len, hmac);
+	else
+		return mpdccp_hmac_sha256(mpcb->dkeyB, mpcb->dkeylen, msg, len, hmac);
 }
 
 
@@ -286,6 +320,7 @@ static int mpdccp_add_addr(struct mpdccp_pm_ns *pm_ns,
 	union inet_addr *addr 		= &event->addr;
     int if_idx 					= event->if_idx;
 	int locaddr_len, loc_id;
+	u16 port;
 
 	struct list_head *plocal_addr_list = &pm_ns->plocal_addr_list;
 
@@ -375,6 +410,7 @@ static int mpdccp_add_addr(struct mpdccp_pm_ns *pm_ns,
 			else
 				local_v4_address.sin_port		= htons (mpcb->server_port);
 
+			port = local_v4_address.sin_port;
 			local = (struct sockaddr *) &local_v4_address;
 			locaddr_len = sizeof (struct sockaddr_in);
 		} else {
@@ -383,6 +419,7 @@ static int mpdccp_add_addr(struct mpdccp_pm_ns *pm_ns,
 			else
 				local_v6_address.sin6_port		= htons (mpcb->server_port);
 
+			port = local_v6_address.sin6_port;
 			local = (struct sockaddr *) &local_v6_address;
 			locaddr_len = sizeof (struct sockaddr_in6);
 		}
@@ -396,7 +433,11 @@ static int mpdccp_add_addr(struct mpdccp_pm_ns *pm_ns,
 						mpcb->remaddr_len);
 			break;
 		case MPDCCP_SERVER:
-			/* do nothing */
+			/* send mp_addaddress */
+			if (!(mpcb->fallback_sp && (mpcb->cnt_subflows > 0))){
+				//add_init_server_conn(mpcb, backlog);
+				mpdccp_send_add_path(local_addr, port, mpcb);
+			}
 			break;
 		default:
 			break;
@@ -493,8 +534,7 @@ static bool mpdccp_del_addr(struct mpdccp_pm_ns *pm_ns,
 
 					addr_id = mpdccp_my_sock(sk)->local_addr_id;
 					mpdccp_close_subflow (mpcb, sk, 0);
-					mpdccp_announce_remove_path(addr_id, mpcb);
-
+					mpdccp_send_remove_path(addr_id, mpcb);
 				}
 			}
 		}
@@ -638,8 +678,7 @@ static void add_pm_event(struct net *net, const struct mpdccp_local_addr_event *
 
 	/* Create work-queue */
 	if (!delayed_work_pending(&pm_ns->address_worker))
-		queue_delayed_work(mpdccp_wq, &pm_ns->address_worker,
-				   msecs_to_jiffies(500));
+		queue_delayed_work(mpdccp_wq, &pm_ns->address_worker, msecs_to_jiffies(10));
 }
 
 static void addr4_event_handler(const struct in_ifaddr *ifa, unsigned long event,
@@ -1256,6 +1295,7 @@ static struct mpdccp_pm_ops mpdccp_pm_default = {
 	.add_remote_addr = pm_add_remote_addr,
 	.get_remote_id = pm_get_remote_id,
 	.free_remote_addr = pm_free_remote_addr_list,
+	.pm_hmac = pm_get_addr_hmac,
 	.name 			= "default",
 	.owner 			= THIS_MODULE,
 };


### PR DESCRIPTION
<h3> This pull request extends #11 and adds support for MP_ADDADDR and MP_REMOVEADDR (issue #10) </h3>

<h4> pm_hmac() function </h4>
This function uses keys from MP_KEY to create an HMAC out of the information from add- and remove-addr options.
The HMAC is then used for sending and verifying that the information is authentic.

<h4> MP_REMOVEADDR </h4>
MP_REMOVEADDR option is triggered by an mpdccp_del_addr() event. This happens if an interface switches state to down.
mpdccp_send_remove_path() is then called which initiates a zero-length DATA packet for the MP_REMOVEADDR and MP_HMAC options.
The option only includes the local id of the subflow that is no longer available. (= remote address id for the receiver)
received MP_REMOVEADDR  options stored as a whole and are only parsed after the HMAC was also parsed.
At this point, the receiver recalculates the HMAC in mpdccp_do_hmac_chk() and compares them, if successful, pm_handle_rm_addr() is called.
This removes the address from premote_list and closes the subflow.

<h4> MP_ADDADDR </h4>
MP_ADDADDR  option is triggered by an mpdccp_add_addr() event on the server. This happens if an interface switches state to up.
MP_ADDADDR  options are currently only sent by the server since the client already reacts to the mpdccp_add_addr() event with an MP_JOIN.
mpdccp_send_add_path() is then called which initiates a zero-length DATA packet for the MP_ADDADDR and MP_HMAC options.
The MP_ADDADDR option can vary in size depending on whether ip6 or ip4 is used. The maximum size is 22 Bytes. Parsing is similar to MP_REMOVEADDR .
Only after the HMAC check was successful,  the address is added to the remote address list with add_remote_addr()
Currently, there are no further actions undertaken after receiving an MP_ADDADDR.
