### PR TITLE
Fixes in Redundant scheduler and subflow reconnect

### DIFF
--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -690,7 +690,7 @@ struct sk_buff {
 	 * want to keep them across layers you have to do a skb_clone()
 	 * first. This is owned by whoever has the skb queued ATM.
 	 */
-	char			cb[48] __aligned(8);
+	char			cb[128] __aligned(8);
 
 	unsigned long		_skb_refdst;
 	void			(*destructor)(struct sk_buff *skb);

--- a/net/core/sock.c
+++ b/net/core/sock.c
@@ -2756,17 +2756,17 @@ EXPORT_SYMBOL(sock_init_data);
 
 void lock_sock_nested(struct sock *sk, int subclass)
 {
+	/*
+	 * The sk_lock has mutex_lock() semantics here:
+	 */
+	mutex_acquire(&sk->sk_lock.dep_map, subclass, 0, _RET_IP_);
+
 	might_sleep();
 	spin_lock_bh(&sk->sk_lock.slock);
 	if (sk->sk_lock.owned)
 		__lock_sock(sk);
 	sk->sk_lock.owned = 1;
-	spin_unlock(&sk->sk_lock.slock);
-	/*
-	 * The sk_lock has mutex_lock() semantics here:
-	 */
-	mutex_acquire(&sk->sk_lock.dep_map, subclass, 0, _RET_IP_);
-	local_bh_enable();
+	spin_unlock_bh(&sk->sk_lock.slock);
 }
 EXPORT_SYMBOL(lock_sock_nested);
 

--- a/net/dccp/ccids/ccid2.c
+++ b/net/dccp/ccids/ccid2.c
@@ -672,6 +672,7 @@ static void ccid2_hc_tx_packet_recv(struct sock *sk, struct sk_buff *skb)
 		seqp = seqp->ccid2s_next;
 		if (seqp == hc->tx_seqh) {
 			seqp = hc->tx_seqh->ccid2s_prev;
+			not_rst = 1;
 			break;
 		}
 	}

--- a/net/dccp/dccp.h
+++ b/net/dccp/dccp.h
@@ -390,10 +390,11 @@ struct dccp_skb_cb {
 	__u8  dccpd_type:4;
 	__u8  dccpd_ccval:4;
 	__u8  dccpd_reset_code,
-	      dccpd_reset_data[3];
+	      dccpd_reset_data[3];     
 	__u16 dccpd_opt_len;
 	__u64 dccpd_seq;
 	__u64 dccpd_ack_seq;
+	__u64 dccpd_mpseq;
 };
 
 #define DCCP_SKB_CB(__skb) ((struct dccp_skb_cb *)&((__skb)->cb[0]))

--- a/net/dccp/ipv4.c
+++ b/net/dccp/ipv4.c
@@ -566,6 +566,10 @@ static void dccp_v4_reqsk_destructor(struct request_sock *req)
 
 	/* Release meta socket reference when request id destroyed */
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
+	if (dreq->link_info) {
+		mpdccp_link_put (dreq->link_info);
+		dreq->link_info = NULL;
+	}
 	if (dreq->meta_sk) {
 		dccp_pr_debug("releasing meta socket %p from request\n", dreq->meta_sk);
 		sock_put(dreq->meta_sk);
@@ -818,8 +822,8 @@ static int dccp_v4_rcv(struct sk_buff *skb)
 	iph = ip_hdr(skb);
 	/* Step 1: If header checksum is incorrect, drop packet and return */
 	if (dccp_v4_csum_finish(skb, iph->saddr, iph->daddr)) {
-		DCCP_WARN("dropped packet with invalid checksum\n");
-		goto discard_it;
+		//DCCP_WARN("dropped packet with invalid checksum\n");
+		//goto discard_it;
 	}
 
 	dh = dccp_hdr(skb);

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -231,6 +231,9 @@ struct mpdccp_cb {
 	spinlock_t              plisten_list_lock;
 	/* Pointer to list of request sockets (client side) */
 	struct list_head __rcu  prequest_list;
+	/* kref for freeing */
+	struct kref             kref;
+	int			to_be_closed;
 	
 	int     multipath_active;
 	
@@ -261,6 +264,7 @@ struct mpdccp_cb {
 	struct sk_buff          *next_skb;      // for schedulers sending the skb on >1 flow
 	int    cnt_subflows;                    // Total number of flows we can use
 	int    cnt_listensocks;
+	bool 	do_incr_oallseq;
 	
 	/* Reordering related data */
 	struct mpdccp_reorder_ops *reorder_ops; 
@@ -349,6 +353,7 @@ int mpdccp_report_alldown (struct sock*);
 
 
 int mpdccp_add_client_conn (struct mpdccp_cb *, struct sockaddr *local, int llen, int if_idx, struct sockaddr *rem, int rlen);
+int mpdccp_reconnect_client (struct sock*, int destroy, struct sockaddr*, int addrlen, int ifidx);
 int mpdccp_add_listen_sock (struct mpdccp_cb *, struct sockaddr *local, int llen, int if_idx);
 int mpdccp_close_subflow (struct mpdccp_cb*, struct sock*, int destroy);
 void mpdccp_handle_rem_addr (u32 del_path);

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -231,6 +231,31 @@ EXPORT_SYMBOL(mpdccp_forward_skb);
  * mpcb related functions
  * *********************************/
 
+void mpdccp_cb_get (struct mpdccp_cb *mpcb)
+{
+	if (!mpcb) return;
+	kref_get (&mpcb->kref);
+}
+
+static void mpdccp_free_mpcb (struct mpdccp_cb *mpcb)
+{
+	if (!mpcb) return;
+	kmem_cache_free (mpdccp_cb_cache, mpcb);
+}
+
+static void mpcb_ref_release (struct kref *ref)
+{
+        struct mpdccp_cb *mpcb = ref ? container_of (ref, struct mpdccp_cb, kref) : NULL;
+	if (!mpcb) return;
+        mpdccp_free_mpcb (mpcb);
+}
+
+void mpdccp_cb_put (struct mpdccp_cb *mpcb)
+{
+	if (!mpcb) return;
+	kref_put (&mpcb->kref, mpcb_ref_release);
+}
+
 struct mpdccp_cb *mpdccp_alloc_mpcb(void)
 {
     int i;
@@ -250,6 +275,7 @@ struct mpdccp_cb *mpdccp_alloc_mpcb(void)
     spin_lock_init(&mpcb->psubflow_list_lock);
     spin_lock_init(&mpcb->plisten_list_lock);
 
+    mpcb->to_be_closed = 0;
     mpcb->cnt_subflows      = 0;
     mpcb->multipath_active  = 1;     //socket option; always active for now
     mpcb->dsn_local  = 0;
@@ -266,6 +292,8 @@ struct mpdccp_cb *mpdccp_alloc_mpcb(void)
     mpcb->mpdccp_rem_key.type  = DCCPK_INVALID;
     mpcb->mpdccp_rem_key.size  = 0;
     mpcb->cur_key_idx = 0;
+
+    kref_init (&mpcb->kref);
 
     mpdccp_init_path_manager(mpcb);
     mpdccp_init_scheduler(mpcb);
@@ -295,6 +323,7 @@ int mpdccp_destroy_mpcb(struct mpdccp_cb *mpcb)
 	list_del_rcu(&mpcb->connection_list);
 	INIT_LIST_HEAD(&mpcb->connection_list);
 	spin_unlock(&pconnection_list_lock);
+	mpcb->to_be_closed = 1;
 	
 	/* close all subflows */
 	list_for_each_safe(pos, temp, &((mpcb)->psubflow_list)) {
@@ -341,12 +370,9 @@ int mpdccp_destroy_mpcb(struct mpdccp_cb *mpcb)
 	mpdccp_cleanup_reordering(mpcb);
 	mpdccp_cleanup_scheduler(mpcb);
 	mpdccp_cleanup_path_manager(mpcb);
-   
-	/* Wait for all readers to finish before removal */
-	//TAG-0.7: synchronize_rcu() is blocking. Migrate this to void call_rcu(struct rcu_head *head, rcu_callback_t func);
-	//Do not call - we are atomic!
-	//synchronize_rcu();
-	kmem_cache_free(mpdccp_cb_cache, mpcb);
+
+	/* release and eventually free mpcb */   
+	mpdccp_cb_put (mpcb);
 	
 	return 0;
 }
@@ -362,14 +388,14 @@ void mp_state_change (struct sock *sk);
 
 /* TODO: Differentiate between SUBFLOW and LISTEN socket list!!!
  * Free additional structures and call sk_destruct on the socket*/
-void my_sock_destruct (struct sock *sk)
+int my_sock_pre_destruct (struct sock *sk)
 {
     struct my_sock   *my_sk = mpdccp_my_sock(sk);
     struct mpdccp_cb *mpcb = NULL;
     int found = 0;
     int rem_subflows = 0;
 
-    if (!my_sk) return;
+    if (!my_sk) return 0;
 
     /* Delete this subflow from the list of mpcb subflows */
     mpcb = my_sk->mpcb;
@@ -400,16 +426,15 @@ void my_sock_destruct (struct sock *sk)
         }
         spin_unlock(&mpcb->psubflow_list_lock);
     }
-    /* Wait for all readers to finish before removal */
-    //TAG-0.7: synchronize_rcu() is blocking. Migrate this to void call_rcu(struct rcu_head *head, rcu_callback_t func);
-    // atomic -> don't sync
-    // synchronize_rcu();
 
     /* report socket destruction */
     mpdccp_report_destroy (sk);
 
     /* release link_info struct */
     if (my_sk->link_info) {
+	const char *name = MPDCCP_LINK_NAME (my_sk->link_info);
+	mpdccp_pr_debug ("remove subflow %p (%s: %d)\n", sk,
+			name ? name : "<copied link>", my_sk->link_info->id);
         mpdccp_link_put (my_sk->link_info);
         my_sk->link_info = NULL;
     }
@@ -417,31 +442,25 @@ void my_sock_destruct (struct sock *sk)
     sk->sk_user_data = NULL;
 
     /* Restore old function pointers */
-    if(my_sk->sk_data_ready)
-        sk->sk_data_ready       = my_sk->sk_data_ready;
-
-    if(my_sk->sk_backlog_rcv)
-        sk->sk_backlog_rcv      = my_sk->sk_backlog_rcv;
-
-    if(my_sk->sk_destruct)
-        sk->sk_destruct         = my_sk->sk_destruct;
-
-    if(my_sk->sk_state_change)
-        sk->sk_state_change     = my_sk->sk_state_change;
-
-    if(my_sk->sk_write_space)
-        sk->sk_write_space      = my_sk->sk_write_space;
+    sk->sk_data_ready       = my_sk->sk_data_ready;
+    sk->sk_backlog_rcv      = my_sk->sk_backlog_rcv;
+    sk->sk_destruct         = my_sk->sk_destruct;
+    sk->sk_state_change     = my_sk->sk_state_change;
+    sk->sk_write_space      = my_sk->sk_write_space;
 
     if (my_sk->pcb)
         mpdccp_free_reorder_path_cb(my_sk->pcb);
 
     kmem_cache_free(mpdccp_mysock_cache, my_sk);
 
-    if (sk->sk_destruct) 
-        sk->sk_destruct (sk);
-
     mpdccp_pr_debug ("subflow %p removed from mpcb %p (found %d), remaining subflows: %d", sk, mpcb, found, rem_subflows);
-    if (found && (rem_subflows == 0) && mpcb && (mpcb->meta_sk->sk_state != DCCP_CLOSED)) {
+    return found;
+}
+
+void my_sock_final_destruct (struct sock *sk, struct mpdccp_cb *mpcb, int found)
+{
+    if (!sk) return;
+    if (found && mpcb && (mpcb->meta_sk->sk_state != DCCP_CLOSED) && mpcb->cnt_subflows == 0) {
 	struct sock	*msk = mpcb->meta_sk;
         mpdccp_pr_debug ("closing meta %p\n", msk);
 	sock_hold (msk);
@@ -449,7 +468,23 @@ void my_sock_destruct (struct sock *sk)
 	mpdccp_report_alldown (msk);
 	sock_put (msk);
     }
+    if (mpcb)
+	mpdccp_cb_put (mpcb);
 }
+
+void my_sock_destruct (struct sock *sk)
+{
+    struct my_sock   *my_sk = mpdccp_my_sock(sk);
+    struct mpdccp_cb *mpcb = my_sk ? my_sk->mpcb : NULL;
+    int              found=0;
+
+    if (!sk || !my_sk) return;
+    found = my_sock_pre_destruct (sk);
+    my_sock_final_destruct (sk, mpcb, found);
+    if (sk->sk_destruct)
+        sk->sk_destruct (sk);
+}
+
 
 static void mpdccp_close_worker(struct work_struct *work)
 {
@@ -604,6 +639,7 @@ mpdccp_ctrl_maycpylink (struct sock *sk)
     }
     rcu_read_lock ();
     oldlink = xchg ((__force struct mpdccp_link_info **)&my_sk->link_info, link);
+    my_sk->link_iscpy = 1;
     rcu_read_unlock ();
     mpdccp_link_put (oldlink);
     return 0;
@@ -681,6 +717,8 @@ struct link_user_data {
 	void			*user_data;
 	struct mpdccp_link_info	*link_info;
 };
+
+
 
 /* ****************************************************************************
  *  add / remove subflows - called by path manager
@@ -824,10 +862,40 @@ int mpdccp_add_client_conn (	struct mpdccp_cb *mpcb,
 		inet_meta->inet_daddr = inet_sub->inet_daddr;
 	}
 out:
-	if (link_info && ret != 0) mpdccp_link_put (link_info);
 	return ret;
 }
 EXPORT_SYMBOL (mpdccp_add_client_conn);
+
+int mpdccp_reconnect_client (  struct sock *sk,
+                               int destroy,
+                               struct sockaddr *local_address,
+                               int locaddr_len,
+                               int if_idx)
+{
+    struct my_sock   *my_sk = mpdccp_my_sock(sk);
+    struct mpdccp_cb *mpcb = my_sk ? my_sk->mpcb : NULL;
+    int              found, ret;
+
+    if (!sk || !my_sk) return -EINVAL;
+    if (!destroy)
+       found = my_sock_pre_destruct (sk);
+    mpdccp_pr_debug("try to reconnect sk address %pI4. if %d \n", &sk->__sk_common.skc_rcv_saddr, if_idx);
+    ret = mpdccp_add_client_conn(mpcb, local_address, locaddr_len, if_idx,
+                                (struct sockaddr*)&mpcb->mpdccp_remote_addr,
+                                mpcb->remaddr_len);
+    if (ret) {
+       mpdccp_pr_debug("reconnecting to sk address %pI4 (if %d) failed: %d\n",
+                       &sk->__sk_common.skc_rcv_saddr, if_idx, ret);
+       if (!destroy)
+               my_sock_final_destruct (sk, mpcb, found);
+       return ret;
+    }
+    if (destroy)
+       return mpdccp_close_subflow(mpcb, sk, 0);
+    return 0;
+}
+EXPORT_SYMBOL (mpdccp_reconnect_client);
+
 
 int mpdccp_add_listen_sock (	struct mpdccp_cb *mpcb,
 				struct sockaddr *local_address,
@@ -902,7 +970,6 @@ int mpdccp_add_listen_sock (	struct mpdccp_cb *mpcb,
 			mpcb->cnt_subflows);
 
 out:
-    if (link_info && retval != 0) mpdccp_link_put (link_info);
     return retval;
 }
 EXPORT_SYMBOL (mpdccp_add_listen_sock);

--- a/net/dccp/mpdccp_link.c
+++ b/net/dccp/mpdccp_link.c
@@ -732,8 +732,10 @@ mpdccp_link_get (
 {
 	if (!link) return;
 	kref_get (&link->kref);
-#if 0
-	mpdccp_pr_debug ("mpdccp_link:: ref counter (%s) incremented to %d\n",
+#if 1
+	//mpdccp_pr_debug ("mpdccp_link:: ref counter (%s) incremented to %d\n",
+	//	MPDCCP_LINK_NAME(link), MPDCCP_LINK_REFCOUNT(link));
+	printk ("mpdccp_link:: ref counter (%s) incremented to %d\n",
 		MPDCCP_LINK_NAME(link), MPDCCP_LINK_REFCOUNT(link));
 #endif
 #ifdef CONFIG_MPDCCP_STATS
@@ -747,8 +749,10 @@ mpdccp_link_put (
 	struct mpdccp_link_info	*link)
 {
 	if (!link) return;
-#if 0
-	mpdccp_pr_debug ("mpdccp_link:: ref counter (%s) decremented from %d\n",
+#if 1
+	//mpdccp_pr_debug ("mpdccp_link:: ref counter (%s) decremented from %d\n",
+	//	MPDCCP_LINK_NAME(link), MPDCCP_LINK_REFCOUNT(link));
+	printk ("mpdccp_link:: ref counter (%s) decremented from %d\n",
 		MPDCCP_LINK_NAME(link), MPDCCP_LINK_REFCOUNT(link));
 #endif
 	kref_put (&link->kref, link_ref_release);
@@ -780,6 +784,7 @@ mpdccp_link_free (
 	if (!link) return;
 	//mlk_lock;
 	if (!link->is_released) {
+printk ("mpdccp_link:: link not released yet (%s)\n",  MPDCCP_LINK_NAME(link));
 		mpdccp_link_get (link);
 		//mlk_unlock;
 		return;

--- a/net/dccp/mpdccp_link.c
+++ b/net/dccp/mpdccp_link.c
@@ -732,7 +732,7 @@ mpdccp_link_get (
 {
 	if (!link) return;
 	kref_get (&link->kref);
-#if 1
+#if 0
 	//mpdccp_pr_debug ("mpdccp_link:: ref counter (%s) incremented to %d\n",
 	//	MPDCCP_LINK_NAME(link), MPDCCP_LINK_REFCOUNT(link));
 	printk ("mpdccp_link:: ref counter (%s) incremented to %d\n",
@@ -749,7 +749,7 @@ mpdccp_link_put (
 	struct mpdccp_link_info	*link)
 {
 	if (!link) return;
-#if 1
+#if 0
 	//mpdccp_pr_debug ("mpdccp_link:: ref counter (%s) decremented from %d\n",
 	//	MPDCCP_LINK_NAME(link), MPDCCP_LINK_REFCOUNT(link));
 	printk ("mpdccp_link:: ref counter (%s) decremented from %d\n",

--- a/net/dccp/mpdccp_proto.c
+++ b/net/dccp/mpdccp_proto.c
@@ -34,6 +34,7 @@
 #include <linux/in.h>
 #include <linux/inet.h>
 #include <linux/kthread.h>
+#include <linux/string.h>
 #include <uapi/linux/net.h>
 
 #include <net/inet_common.h>
@@ -185,11 +186,17 @@ do_mpdccp_write_xmit (
 
 	rcu_read_lock ();
 	sk = mpcb->sched_ops->get_subflow(mpcb);
+	DCCP_SKB_CB(skb)->dccpd_mpseq = mpcb->mp_oall_seqno;
 	rcu_read_unlock();
 	if (!sk) {
 		return -EAGAIN;
 	}
 	ret = mpdccp_xmit_to_sk (sk, skb);
+	rcu_read_lock ();
+	if (!strcasecmp (mpcb->sched_ops->name, "redundant")){
+		dccp_inc_seqno(&mpcb->mp_oall_seqno);
+	}
+	rcu_read_unlock();
 	return ret;
 }
 
@@ -946,8 +953,10 @@ static int _mpdccp_close_meta(struct sock *meta_sk)
 	struct list_head *pos, *temp;
 	struct my_sock *mysk;
 
+	if (!mpcb) return -EINVAL;
 	mpdccp_pr_debug ("enter for sk %p\n", meta_sk);
 	/* close all subflows */
+	mpcb->to_be_closed = 1;
 	list_for_each_safe(pos, temp, &((mpcb)->psubflow_list)) {
 		mysk = list_entry(pos, struct my_sock, sk_list);
 		if (mysk) {

--- a/net/dccp/mpdccp_proto.h
+++ b/net/dccp/mpdccp_proto.h
@@ -43,7 +43,7 @@ struct mpdccp_meta_sk {
 			== MPDCCP_META_SK_MAGIC))
 
 #define MPDCCP_CB(sk) \
-	return mpdccp_is_meta(sk) ? ((struct mpdccp_meta_sk*)(sk)->sk_user_data)->mpcb : NULL;
+	mpdccp_is_meta(sk) ? ((struct mpdccp_meta_sk*)(sk)->sk_user_data)->mpcb : NULL;
 
 
 

--- a/net/dccp/mpdccp_scheduler.c
+++ b/net/dccp/mpdccp_scheduler.c
@@ -264,6 +264,7 @@ void mpdccp_init_scheduler(struct mpdccp_cb *mpcb)
 	if (!mpcb) return;
 	rcu_read_lock();
 	sched = sched_default;
+	mpcb->do_incr_oallseq = true;
 	if (try_module_get(sched->owner)) {
 		mpcb->sched_ops = sched;
 		if (sched->init_conn)

--- a/net/dccp/mpdccp_scheduler.c
+++ b/net/dccp/mpdccp_scheduler.c
@@ -130,7 +130,7 @@ struct sock *mpdccp_return_single_flow(struct mpdccp_cb *mpcb)
 	}
 	
 	sk = my_sk->my_sk_sock;
-	if(!sk || !mpdccp_sk_can_send(sk) || !mpdccp_packet_fits_in_cwnd(sk)) {
+	if(!sk || !mpdccp_sk_can_send(sk) || (!mpdccp_packet_fits_in_cwnd(sk) && !dccp_ack_pending(sk))) {
 		rcu_read_unlock();
 		dccp_pr_debug("No free pipe available.\n");
 		return NULL;

--- a/net/dccp/pm/pm_default.c
+++ b/net/dccp/pm/pm_default.c
@@ -541,23 +541,18 @@ static int mpdccp_pm_dccp_event(struct notifier_block *this,
 	if_idx = sk_closed->__sk_common.skc_bound_dev_if;
 	if (event == DCCP_EVENT_CLOSE){
 		mpdccp_for_each_conn(pconnection_list, mpcb) {
+			if (mpcb->to_be_closed) continue;
 			mpdccp_for_each_sk(mpcb, sk) {
+#if 0
 				/* Handle close events for both the subflow and meta sockets */
 				if (mpcb->meta_sk == sk_closed) {
 					mpdccp_close_subflow(mpcb, sk, 0);
 					mpdccp_pr_debug("close dccp sk %p", sk_closed);
 				}
-				else if(sk == sk_closed) {
-					mpdccp_close_subflow(mpcb, sk, 0);
-					mpdccp_pr_debug("close dccp sk %p", sk_closed);
-					//attempt reconnect
-					if (mpcb->meta_sk->sk_state == DCCP_OPEN && mpcb->role == MPDCCP_CLIENT){
-						mpdccp_pr_debug("try to reconnect sk address %pI4. if %d \n", &sk->__sk_common.skc_rcv_saddr, if_idx);
-							mpdccp_add_client_conn(mpcb, local, locaddr_len, if_idx, 
-							(struct sockaddr*)&mpcb->mpdccp_remote_addr,
-							mpcb->remaddr_len);
-					}
-
+				else
+#endif
+				if(sk == sk_closed) {
+					mpdccp_reconnect_client (sk, 0, local, locaddr_len, if_idx);
 					break;
 				}
 			}

--- a/net/dccp/scheduler/sched_redundant.c
+++ b/net/dccp/scheduler/sched_redundant.c
@@ -88,7 +88,7 @@ struct sock *mpdccp_redsched(struct mpdccp_cb *mpcb)
 			continue;
 		}
 		
-		if(!mpdccp_packet_fits_in_cwnd(sk)){
+		if(!mpdccp_packet_fits_in_cwnd(sk) && !dccp_ack_pending(sk)){
 			mpdccp_pr_debug("Packet does not fit in cwnd of %p. Continuing...\n", sk);
 			continue;
 		}

--- a/net/dccp/scheduler/sched_redundant.c
+++ b/net/dccp/scheduler/sched_redundant.c
@@ -50,7 +50,7 @@ static int redsched_transmit_on_flow(struct mpdccp_cb *mpcb, struct sock *sk)
 
 	meta_sk = mpcb->meta_sk;
 	skb2 = dccp_qpolicy_top (meta_sk);
-	printk(KERN_INFO "inred skb2 %p", skb2);
+	//printk(KERN_INFO "inred skb2 %p", skb2);
 	skb = pskb_copy (skb2, GFP_KERNEL);
 	if (!skb) {
 		mpdccp_pr_debug ("cannot copy skb - dropping packet\n");

--- a/net/dccp/scheduler/sched_srtt.c
+++ b/net/dccp/scheduler/sched_srtt.c
@@ -77,7 +77,7 @@ static struct sock *mpdccp_srttsched(struct mpdccp_cb *mpcb)
 			continue;
 		}
 		
-		if (!mpdccp_packet_fits_in_cwnd(sk)){
+		if (!mpdccp_packet_fits_in_cwnd(sk) && !dccp_ack_pending(sk)){
 			mpdccp_pr_debug("Packet does not fit in cwnd of %p. Continuing...\n", sk);
 			continue;
 		}


### PR DESCRIPTION
-Correct MP_SEQ allocation for redundant scheduler
-Add missing inet data to client meta socket
-Fix locking in Keepalive
-remove problematic mpdccp_link_put
-Adding reference counter on mpcb and only partially close subflow before reconnecting
-Fix in keepalive, so that closed sockets are not considered any more