### PR TITLE
Implementation of missing mp_rtt option features from #21 

### DIFF
--- a/net/dccp/ccid.c
+++ b/net/dccp/ccid.c
@@ -26,7 +26,7 @@ static struct ccid_operations *ccids[] = {
 #endif
 };
 
-u32 (*get_delay_valn)(struct sock *sk, struct tcp_info *info, u8 *type) = srtt_as_delayn;
+u32 (*get_delay_valn)(struct sock *sk, struct tcp_info *info, u8 *type) = mrtt_as_delayn;
 EXPORT_SYMBOL_GPL(get_delay_valn);
 
 static struct ccid_operations *ccid_by_number(const u8 id)

--- a/net/dccp/ccid.h
+++ b/net/dccp/ccid.h
@@ -291,6 +291,32 @@ static inline u32 mrtt_as_delayn(struct sock *sk, struct tcp_info *info, u8 *typ
     else{ return 0; }
 }
 
+/**
+ * Obtain Min RTT value form CCID2 TX sock.
+ */
+static inline u32 min_rtt_as_delayn(struct sock *sk, struct tcp_info *info, u8 *type){
+    if(dccp_sk(sk)->dccps_hc_tx_ccid != NULL) { 
+		*type = 1;
+    	ccid_hc_tx_get_info(dccp_sk(sk)->dccps_hc_tx_ccid, sk, info);
+		// overwrite age field to display correct timestamp
+		info->tcpi_last_ack_recv = info->tcpi_last_ack_sent;
+    	return jiffies_to_msecs(info->tcpi_min_rtt); }
+    else{ return 0; }
+}
+
+/**
+ * Obtain Max RTT value form CCID2 TX sock.
+ */
+static inline u32 max_rtt_as_delayn(struct sock *sk, struct tcp_info *info, u8 *type){
+    if(dccp_sk(sk)->dccps_hc_tx_ccid != NULL) { 
+		*type = 2;
+    	ccid_hc_tx_get_info(dccp_sk(sk)->dccps_hc_tx_ccid, sk, info);
+		// overwrite age field to display correct timestamp
+		info->tcpi_last_ack_recv = info->tcpi_rcv_mss;
+    	return jiffies_to_msecs(info->tcpi_snd_mss); }
+    else{ return 0; }
+}
+
 extern u32 (*get_delay_valn)(struct sock *sk, struct tcp_info *info, u8 *type);
 
 static inline void set_srtt_as_delayn(void){
@@ -299,5 +325,13 @@ static inline void set_srtt_as_delayn(void){
 
 static inline void set_mrtt_as_delayn(void){
     get_delay_valn = mrtt_as_delayn;
+}
+
+static inline void set_min_rtt_as_delayn(void){
+    get_delay_valn = min_rtt_as_delayn;
+}
+
+static inline void set_max_rtt_as_delayn(void){
+    get_delay_valn = max_rtt_as_delayn;
 }
 #endif /* _CCID_H */

--- a/net/dccp/ccids/ccid2.h
+++ b/net/dccp/ccids/ccid2.h
@@ -84,6 +84,10 @@ struct ccid2_hc_tx_sock {
 				tx_mdev_max,
 				tx_rttvar,
 				tx_rto,
+				tx_min_rtt,
+				tx_max_rtt,
+				tx_min_rtt_stamp,	        /* timestamp of min_rtt_us */
+				tx_max_rtt_stamp,	        /* timestamp of max_rtt_us */
 				tx_last_ack_recv;
 	u64			tx_rtt_seq:48;
 	struct timer_list	tx_rtotimer;

--- a/net/dccp/ccids/ccid5.c
+++ b/net/dccp/ccids/ccid5.c
@@ -1035,6 +1035,12 @@ static void bbr_update_rt_prop(struct sock *sk, const struct rate_sample_dccp *r
 		hc->min_rtt_stamp = ccid5_jiffies32;
 		}
 
+	if (rs->rtt_us > 0 &&
+		hc->max_rtt_us <= rs->rtt_us){
+		hc->max_rtt_us = rs->rtt_us;
+		hc->max_rtt_stamp = ccid5_jiffies32;
+	}
+
 	//Equivalent to check_probe_rtt
 	if (bbr_probe_rtt_mode_ms > 0 && filter_expired &&
 	    !hc->idle_restart && hc->mode != BBR_PROBE_RTT) {
@@ -1435,6 +1441,7 @@ static int ccid5_hc_tx_init(struct ccid *ccid, struct sock *sk)
 	hc->tx_cwnd_used = 0;
 	hc->tx_pipe = 0;
 	hc->min_rtt_us = 0;
+	hc->max_rtt_us = 0;
 
 	hc->prior_cwnd = 0;
 	hc->tso_segs_goal = 0;	 /* default segs per skb until first ACK */
@@ -1447,6 +1454,7 @@ static int ccid5_hc_tx_init(struct ccid *ccid, struct sock *sk)
 	hc->probe_rtt_done_stamp = 0;
 	hc->probe_rtt_round_done = 0;
 	hc->min_rtt_stamp = ccid5_jiffies32;
+	hc->max_rtt_stamp = ccid5_jiffies32;
 
 
 	hc->has_seen_rtt = 0;
@@ -1509,6 +1517,14 @@ static void ccid5_hc_tx_get_info(struct sock *sk, struct tcp_info *info)
 	info->tcpi_snd_cwnd = ccid5_hc_tx_sk(sk)->tx_cwnd;
 	info->tcpi_last_data_sent = ccid5_hc_tx_sk(sk)->tx_lsndtime;
 	info->tcpi_last_ack_recv = (ccid5_hc_tx_sk(sk)->tx_last_ack_recv > 0) ? ccid5_jiffies32 - ccid5_hc_tx_sk(sk)->tx_last_ack_recv : 0;
+	
+	info->tcpi_min_rtt = ccid5_hc_tx_sk(sk)->min_rtt_us;
+	//calculate time since tx_min_rtt_stamp was set and store it in some unused var.
+	info->tcpi_last_ack_sent = (ccid5_hc_tx_sk(sk)->min_rtt_stamp > 0) ? ccid5_jiffies32 - ccid5_hc_tx_sk(sk)->min_rtt_stamp : 0;
+	
+	info->tcpi_snd_mss = ccid5_hc_tx_sk(sk)->max_rtt_us;
+	//calculate time since tx_min_rtt_stamp was set and store it in some unused var.
+	info->tcpi_rcv_mss = (ccid5_hc_tx_sk(sk)->max_rtt_stamp > 0) ? ccid5_jiffies32 - ccid5_hc_tx_sk(sk)->max_rtt_stamp : 0;
 }
 
 struct ccid_operations ccid5_ops = {

--- a/net/dccp/ccids/ccid5.h
+++ b/net/dccp/ccids/ccid5.h
@@ -106,7 +106,9 @@ struct ccid5_hc_tx_sock {
 
 	/* variables of BBR struct */
 	u32			min_rtt_us;
+	u32			max_rtt_us;
 	u32			min_rtt_stamp;	        /* timestamp of min_rtt_us */
+	u32			max_rtt_stamp;	        /* timestamp of min_rtt_us */
 	u32			probe_rtt_done_stamp;   /* end time for BBR_PROBE_RTT mode */
 	u32 		mode:3,		     /* current bbr_mode in state machine */
 				prev_ca_state:3,     /* CA state on previous ACK */

--- a/net/dccp/mpdccp_reordering.h
+++ b/net/dccp/mpdccp_reordering.h
@@ -74,8 +74,10 @@ extern int ro_dbug_state;
 
 /* Reordering delay types */
 enum {
-    MPDCCP_REORDERING_DELAY_SRTT,
-    MPDCCP_REORDERING_DELAY_MRTT,
+	MPDCCP_REORDERING_DELAY_MRTT,		// raw_rtt	= 0
+	MPDCCP_REORDERING_DELAY_MIN_RTT,	// min_rtt	= 1
+	MPDCCP_REORDERING_DELAY_MAX_RTT,	// max_rtt	= 2
+	MPDCCP_REORDERING_DELAY_SRTT,		// srtt		= 3
     MPDCCP_REORDERING_DELAY_KRTT     
 };
 

--- a/net/dccp/mpdccp_sysctl.c
+++ b/net/dccp/mpdccp_sysctl.c
@@ -200,22 +200,30 @@ static int proc_mpdccp_delay_config(struct ctl_table *table, int write,
 	
 	if(ret == 0){
 		switch(sysctl_mpdccp_delay_config){
-		case MPDCCP_REORDERING_DELAY_SRTT:
-			mpdccp_pr_debug("Switched to SRTT\n");
-			set_srtt_as_delay();
-			break;
 		case MPDCCP_REORDERING_DELAY_MRTT:
 			mpdccp_pr_debug("Switched to MRTT\n");
-			set_mrtt_as_delay();
+			set_mrtt_as_delayn();
+			break;
+		case MPDCCP_REORDERING_DELAY_MIN_RTT:
+			mpdccp_pr_debug("Switched to Min RTT\n");
+			set_min_rtt_as_delayn();
+			break;
+		case MPDCCP_REORDERING_DELAY_MAX_RTT:
+			mpdccp_pr_debug("Switched to Max RTT\n");
+			set_max_rtt_as_delayn();
+			break;
+		case MPDCCP_REORDERING_DELAY_SRTT:
+			mpdccp_pr_debug("Switched to SRTT\n");
+			set_srtt_as_delayn();
 			break;
 		default:
 			mpdccp_pr_debug("Parameter %d unknown, switched to SRTT\n", sysctl_mpdccp_delay_config);
-			set_srtt_as_delay();
+			set_srtt_as_delayn();
 			break;
 		}
 	} else {
-		set_srtt_as_delay();
-	}    
+		set_srtt_as_delayn();
+	}
 	return ret;
 }
 
@@ -239,7 +247,7 @@ struct ctl_table mpdccp_table[] = {
 		.proc_handler = proc_mpdccp_reordering,
 	},
 	{
-		.procname = "mpdccp_delay_config",
+		.procname = "mpdccp_rtt_config",
 		.data = &sysctl_mpdccp_delay_config,
 		.maxlen = sizeof(int),
 		.mode = 0644,

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -1028,6 +1028,7 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 	 * congestion control */
 	if (is_mpdccp(sk)) {
 		struct mpdccp_cb *mpcb = get_mpcb(sk);
+		struct my_sock  *my_sk = mpdccp_my_sock(sk);
 		u8 mp_addr_id = get_id(sk);
 
 		/* Skip if fallback to sp DCCP */
@@ -1044,9 +1045,13 @@ int dccp_insert_options(struct sock *sk, struct sk_buff *skb)
 					u8 rtt_type;
 					u32 rtt_value = get_delay_valn(sk, &info, &rtt_type);
 					u32 rtt_age = jiffies_to_msecs(info.tcpi_last_ack_recv);
-					dccp_insert_option_mp_rtt(skb, rtt_type, rtt_value, rtt_age);
-					dccp_pr_debug("delay = %u age %u on socket (0x%p) loc_id: %u rem_id: %u", rtt_value, rtt_age, sk, mp_addr_id, mpdccp_my_sock(sk)->remote_addr_id);
-				}				
+
+					if(rtt_value){
+						dccp_insert_option_mp_rtt(skb, rtt_type, rtt_value, rtt_age);
+						dccp_pr_debug("RTT: %u type: %u age: %u on socket (0x%p) loc_id: %u rem_id: %u", 
+								rtt_value, rtt_type, rtt_age, sk, mp_addr_id, my_sk->remote_addr_id);
+					}
+				}
 				if(mpcb){
 
 					if(mpcb->announce_prio[2]){


### PR DESCRIPTION
Added min_rtt and max_rtt option to mp_rtt for both ccid2 and ccid5

Renamed and integrated sysctl interface mpdccp_delay_config -> mpdccp_rtt_config.
The type of rtt info that is transmitted can be changed with e.g.: `sysctl -w net.mpdccp.mpdccp_rtt_config=2`
Following values can be selected:

0 = mrtt
1 = min_rtt
2 = max_rtt
3 = srtt

For mrtt and srtt the age parameter will always display the time between sending the option and receiving the last ack.
For min and max_rtt the age parameter displays the time between sending the option and receiving the ack with either smallest or biggest measured rtt.
All values are in milliseconds