### PR TITLE
Fixing issues mentioned in #23

### DIFF
--- a/net/dccp/mpdccp_pm.h
+++ b/net/dccp/mpdccp_pm.h
@@ -52,8 +52,8 @@ struct mpdccp_pm_ns {
 	struct list_head	events;
 	struct delayed_work	address_worker;
 
-	u8 loc4_bits;
-	
+	u64 loc4_bits;
+
 	struct net		*net;
 };
 
@@ -68,14 +68,13 @@ struct mpdccp_pm_ops {
 	
 	int			(*add_init_server_conn) (struct mpdccp_cb*, int);
 	int			(*add_init_client_conn) (struct mpdccp_cb*, struct sockaddr*, int);
-	int			(*get_local_id)         (const struct sock*, sa_family_t, union inet_addr*, int);
-	void		(*rm_remote_addr)       (u8);
-	void		(*add_remote_addr)      (struct mpdccp_cb*, sa_family_t, u8, union inet_addr*, u16);
-	int			(*get_remote_id)		(struct mpdccp_cb*, union inet_addr*, sa_family_t);
-	void		(*free_remote_addr)     (struct mpdccp_cb*);
+	int			(*claim_local_addr)     (struct mpdccp_cb*, sa_family_t, union inet_addr*);
+	void		(*del_addr)       		(struct mpdccp_cb*, u8, bool, bool);
+	void		(*add_addr)             (struct mpdccp_cb*, sa_family_t, u8, union inet_addr*, u16, bool);
+	int			(*get_id_from_ip)       (struct mpdccp_cb*, union inet_addr*, sa_family_t, bool);
+	int 		(*get_hmac)				(struct mpdccp_cb*, u8, sa_family_t, union inet_addr*, u16, bool, u8*);
+	void		(*rcv_removeaddr_opt)   (struct mpdccp_cb*, u8);
 	void 		(*handle_rcv_prio)		(struct mpdccp_cb*, u8, u8);
-	int 		(*pm_hmac)				(struct mpdccp_cb*, u8, sa_family_t, union inet_addr*, u16, bool, u8*);
-	
 	char			name[MPDCCP_PM_NAME_MAX];
 	struct module		*owner;
 };

--- a/net/dccp/mpdccp_proto.c
+++ b/net/dccp/mpdccp_proto.c
@@ -381,8 +381,6 @@ _mpdccp_connect (
 	return 0;
 }
 
-
-
 static
 int
 _mpdccp_destroy_sock (
@@ -397,10 +395,6 @@ _mpdccp_destroy_sock (
 	module_put (THIS_MODULE);
 	return 0;
 }
-
-
-
-
 
 static int _mpdccp_conn_request(struct sock *sk, struct dccp_request_sock *dreq)
 {
@@ -486,6 +480,7 @@ static int _mpdccp_conn_request(struct sock *sk, struct dccp_request_sock *dreq)
 
 	return 0;
 }
+
 static int _mpdccp_rcv_request_sent_state_process(struct sock *sk, const struct sk_buff *skb)
 {
 	struct mpdccp_cb *mpcb;
@@ -668,7 +663,6 @@ static int _mpdccp_rcv_respond_partopen_state_process(struct sock *sk, int type)
 	return 0;
 }
 
-
 static int
 create_subflow(
 	struct sock *sk,
@@ -801,14 +795,14 @@ _mpdccp_create_master(
 	mpcb->master_addr_id = 0;
 
 	addr.ip = inet->inet_saddr;
-	if(mpcb->pm_ops->get_local_id)
-		mpcb->master_addr_id = mpcb->pm_ops->get_local_id(meta_sk, AF_INET, &addr, 0);
+	if(mpcb->pm_ops->claim_local_addr)
+		mpcb->master_addr_id = mpcb->pm_ops->claim_local_addr(mpcb, AF_INET, &addr);
 
 	mpdccp_pr_debug("master subflow id: %u\n", mpcb->master_addr_id);
 
 	addr.ip = inet->inet_daddr;
-	if(mpcb->pm_ops->add_remote_addr)
-		mpcb->pm_ops->add_remote_addr(mpcb, AF_INET, 0, &addr, inet->inet_dport);
+	if(mpcb->pm_ops->add_addr)
+		mpcb->pm_ops->add_addr(mpcb, AF_INET, 0, &addr, inet->inet_dport, true);
 
 	/* Create subflow and meta sockets */
 	ret = create_subflow(sk, meta_sk, skb, req, 1, mpcb->master_addr_id, 0);
@@ -951,11 +945,11 @@ static int _mpdccp_check_req(struct sock *sk, struct sock *newsk, struct request
 		}
 		mpdccp_pr_debug("HMAC validation OK");
 
-		if(mpcb->pm_ops->get_local_id && mpcb->pm_ops->get_remote_id){
+		if(mpcb->pm_ops->get_id_from_ip){
 			addr.ip = ip_hdr(skb)->daddr;
-			loc_id = mpcb->pm_ops->get_local_id(mpcb->meta_sk, AF_INET, &addr, 0);
+			loc_id = mpcb->pm_ops->get_id_from_ip(mpcb, &addr, AF_INET, false);
 			addr.ip = ip_hdr(skb)->saddr;
-			rem_id = mpcb->pm_ops->get_remote_id(mpcb, &addr, AF_INET);
+			rem_id = mpcb->pm_ops->get_id_from_ip(mpcb, &addr, AF_INET, true);
 
 			if(loc_id < 0 || rem_id < 0){
 				mpdccp_pr_debug("cant create subflow with unknown address id");
@@ -1002,6 +996,10 @@ static int _mpdccp_close_meta(struct sock *meta_sk)
 			}
 		}
 	}
+
+	if(mpcb->pm_ops->del_addr)
+		mpcb->pm_ops->del_addr(mpcb, 0, 0, true);
+
 	return ret;
 }
 


### PR DESCRIPTION
This is a bigger pull request with multiple changes.

It includes many cosmetic changes. 
- In options.c I split up the `dccp_insert_options()` function into dccp and mpdccp.
- Renamed many functions for consistency. e.g. pm_... is only used inside the pathmanager.
- Removed unused old code and cleaned up some files.

Complete overhaul of address id implementation in the pathmanager.

- Adding functionality to store local and remote addresses in connection memory (`struct mpcb`) 
- moved many socket-specific flags from mpcb to the individual sockets (`struct my_sock`).
- Also implemented the sequence number check to addaddr option handling that was added in a recent draft update.