### PR TITLE
Implementing updated version of MP_PRIO option (issue #18)

### DIFF
--- a/include/net/mpdccp_link.h
+++ b/include/net/mpdccp_link.h
@@ -84,6 +84,7 @@ MPDCCP_DEV_CHANGE(mpdccp_match_mask,u32)
 MPDCCP_DEV_CHANGE(mpdccp_send_mark,u32)
 MPDCCP_DEV_CHANGE(mpdccp_path_type,u32)
 MPDCCP_DEV_CHANGE(mpdccp_match_pathtype,u32)
+int mpdccp_link_change_name (struct mpdccp_link_info *link, struct sock *sk);
 int mpdccp_link_change_mpdccp_cgstalg(struct mpdccp_link_info *, const char *, size_t );
 static inline int dev_change_mpdccp_cgstalg(struct net_device *dev, const char *buf, size_t len)
 {

--- a/include/net/mpdccp_link_info.h
+++ b/include/net/mpdccp_link_info.h
@@ -11,7 +11,8 @@
 struct mpdccp_link_info {
 
 	struct list_head	link_list;
-	char			name[IFNAMSIZ+1];
+//	char			name[IFNAMSIZ+1];
+	char			name[64];
 	int			id;
 	u32			is_linked:1,
 				is_devlink:1,

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -90,6 +90,7 @@ static const char *mpdccp_state_name(const int state)
 #endif
 
 extern bool mpdccp_debug;
+extern bool mpdccp_accept_prio;
 #ifdef CONFIG_IP_MPDCCP_DEBUG
 #define MPDCCP_PRINTK(enable, fmt, args...)   do { if (enable)                  \
                             printk_ratelimited(fmt, ##args);                    \
@@ -259,7 +260,6 @@ struct mpdccp_cb {
 	int                     remaddr_len;	// length of mpdccp_remote_addr;
 	u16			    server_port;	// Server only 
 	int			    backlog;
-	u8			announce_prio[3];				// id, prio, flag for send
 
 	int			up_reported;
 	u8 			master_addr_id;
@@ -325,6 +325,12 @@ struct my_sock
 	int     if_idx; /* Interface ID, used for event handling */
 
 /* following data is used for sending options*/
+
+	/* send mp_prio option with next packet:*/
+	u8  announce_prio;
+	bool prio_rcvrd;
+	/* prio was changed with this sequence number */
+	u64 last_prio_seq;
 
 	u8 delpath_id;
 	bool delpath_sent;
@@ -405,7 +411,7 @@ int mpdccp_xmit_to_sk (struct sock *sk, struct sk_buff *skb);
 
 void mpdccp_init_announce_prio(struct sock *sk);
 int mpdccp_get_prio(struct sock *sk);
-int mpdccp_set_prio(struct sock *sk, int prio);
+int mpdccp_link_cpy_set_prio(struct sock *sk, int prio);
 
 /* Functions for authentication */
 int mpdccp_hash_key(const u8 *in, u8 inlen, u32 *token);
@@ -434,6 +440,8 @@ static inline u8 get_id(struct sock *sk)
     return chk_id(mpdccp_my_sock(sk)->local_addr_id, mpdccp_my_sock(sk)->mpcb->master_addr_id);
 }
 
+static inline void mpdccp_set_accept_prio(void){mpdccp_accept_prio = true;}
+static inline void mpdccp_set_ignore_prio(void){mpdccp_accept_prio = false;}
 
 #endif /* _MPDCCP_H */
 

--- a/net/dccp/mpdccp_link.c
+++ b/net/dccp/mpdccp_link.c
@@ -136,6 +136,16 @@ found:
 }
 EXPORT_SYMBOL(mpdccp_link_find_by_name);
 
+int mpdccp_link_change_name (struct mpdccp_link_info *link, struct sock *sk) {
+	char newname[64];
+
+	snprintf(newname, 64, "%s_%pI4:%u", link->ndev_name,
+				&sk->__sk_common.skc_daddr, sk->__sk_common.skc_dport);
+	strcpy(link->ndev_name, "mp_prio");
+	return mpdccp_link_sysfs_changename(link, newname);
+}
+EXPORT_SYMBOL(mpdccp_link_change_name);
+
 struct mpdccp_link_info*
 mpdccp_link_find_by_dev (
 	struct net_device	*dev)
@@ -785,10 +795,14 @@ mpdccp_link_free (
 	if (!link) return;
 	//mlk_lock;
 	if (!link->is_released) {
-printk ("mpdccp_link:: link not released yet (%s)\n",  MPDCCP_LINK_NAME(link));
-		mpdccp_link_get (link);
-		//mlk_unlock;
-		return;
+		mpdccp_pr_info ("mpdccp_link:: link not released yet (%s) ref cnt: %d",
+				MPDCCP_LINK_NAME(link), MPDCCP_LINK_REFCOUNT(link));
+		
+		if(strcmp(link->ndev_name, "mp_prio")) {
+			mpdccp_link_get (link);
+			return;
+		}
+		mpdccp_link_release_nolock(link);
 	}
 	if (MPDCCP_LINK_ISDEV(link)) {
 		mpdccp_pr_info ("mpdccp_link:: device link freed (dev=%s)\n", link->ndev_name);
@@ -804,6 +818,7 @@ void
 mpdccp_link_release (
 	struct mpdccp_link_info	*link)
 {
+	mpdccp_pr_info ("mpdccp_link:: named link %s released\n", link->name);
 	if (!link) return;
 	mlk_lock;
 	mpdccp_link_release_nolock (link);

--- a/net/dccp/mpdccp_mod.c
+++ b/net/dccp/mpdccp_mod.c
@@ -54,8 +54,12 @@
 bool mpdccp_debug;
 module_param(mpdccp_debug, bool, 0644);
 MODULE_PARM_DESC(mpdccp_debug, "Enable debug messages");
-
 EXPORT_SYMBOL(mpdccp_debug);
+
+bool mpdccp_accept_prio;
+module_param(mpdccp_accept_prio, bool, 0644);
+MODULE_PARM_DESC(mpdccp_accept_prio, "Accept priority from incoming mp_prio options");
+EXPORT_SYMBOL(mpdccp_accept_prio);
 
 int mpdccp_sysctl_init (void);
 int mpdccp_ctrl_init (void);

--- a/net/dccp/mpdccp_pm.h
+++ b/net/dccp/mpdccp_pm.h
@@ -74,7 +74,8 @@ struct mpdccp_pm_ops {
 	int			(*get_id_from_ip)       (struct mpdccp_cb*, union inet_addr*, sa_family_t, bool);
 	int 		(*get_hmac)				(struct mpdccp_cb*, u8, sa_family_t, union inet_addr*, u16, bool, u8*);
 	void		(*rcv_removeaddr_opt)   (struct mpdccp_cb*, u8);
-	void 		(*handle_rcv_prio)		(struct mpdccp_cb*, u8, u8);
+	void 		(*rcv_prio_opt)			(struct sock*, u8, u64);
+
 	char			name[MPDCCP_PM_NAME_MAX];
 	struct module		*owner;
 };

--- a/net/dccp/mpdccp_proto.c
+++ b/net/dccp/mpdccp_proto.c
@@ -649,8 +649,18 @@ static int _mpdccp_rcv_respond_partopen_state_process(struct sock *sk, int type)
 		/* Authentication complete, send an additional ACK if required */
 		dccp_sk(sk)->auth_done = 1;
 		if (dccp_sk(sk)->dccps_role == DCCP_ROLE_SERVER) {
+			struct mpdccp_link_info *link = mpdccp_ctrl_getlink (sk);
+
 			mpdccp_pr_debug("send ACK");
 			dccp_send_ack(sk);
+
+			/* we have a virtual link (created by a script or mpdccplink add_link) */
+			if(link && !link->is_devlink && link->mpdccp_prio != 3)
+				mpdccp_init_announce_prio(sk);			// (server) announce prio only for non dev links
+			else if(link && link->is_devlink)
+				mpdccp_link_cpy_set_prio(sk, 3);
+			
+			mpdccp_link_put (link);
 		}
 	}
 

--- a/net/dccp/mpdccp_sysctl.c
+++ b/net/dccp/mpdccp_sysctl.c
@@ -44,7 +44,7 @@
 struct  ctl_table_header *mpdccp_sysctl;
 /* Controls whether the client sends SRTT or MRTT */
 int sysctl_mpdccp_delay_config __read_mostly    = 0;
-
+int sysctl_mpdccp_accept_prio __read_mostly    = 0;
 
 
 static int proc_mpdccp_path_manager(struct ctl_table *ctl, int write,
@@ -227,6 +227,21 @@ static int proc_mpdccp_delay_config(struct ctl_table *table, int write,
 	return ret;
 }
 
+static int proc_mpdccp_accept_prio(struct ctl_table *table, int write,
+                void __user *buffer, size_t *lenp,
+                loff_t *ppos)
+{
+	int ret = proc_dointvec(table, write, buffer, lenp, ppos);
+
+	if(ret == 0){
+		if(sysctl_mpdccp_accept_prio > 0)
+			mpdccp_set_accept_prio();
+		else
+			mpdccp_set_ignore_prio();
+	}
+	return ret;
+}
+
 struct ctl_table mpdccp_table[] = {
 	{
 		.procname = "mpdccp_path_manager",
@@ -252,6 +267,13 @@ struct ctl_table mpdccp_table[] = {
 		.maxlen = sizeof(int),
 		.mode = 0644,
 		.proc_handler = proc_mpdccp_delay_config,
+	},
+	{
+		.procname = "mpdccp_accept_prio",
+		.data = &sysctl_mpdccp_accept_prio,
+		.maxlen = sizeof(int),
+		.mode = 0644,
+		.proc_handler = proc_mpdccp_accept_prio,
 	},
 	{
 		.procname = "mpdccp_debug",


### PR DESCRIPTION
mp_prio fully reworked and updated to latest draft spec. Both sides can now send mp_prio options. The server will always use virtual links that can be modified (we create new temporary ones if none are pre-assigned). Added sysctl `mpdccp_accept_prio` parameter, default is 0, meaning incoming mp_prio options will be ignored. 
If it's set, received mp_prio options will be used for the current connection instead of the local prios