### PR TITLE
Implementation of the missing MP_CONFIRM option

### DIFF
--- a/include/uapi/linux/dccp.h
+++ b/include/uapi/linux/dccp.h
@@ -250,6 +250,7 @@ enum dccp_packet_dequeueing_policy {
 #define MPDCCP_HMAC_SIZE 20
 
 #define MPDCCP_ADDADDR_SIZE 22
+#define MPDCCP_CONFIRM_SIZE 31
 
 /* MPDCCP version type */
 enum mpdccp_version {

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -340,7 +340,14 @@ struct my_sock
 	u8 addpath_hmac[MPDCCP_HMAC_SIZE];
 
 	u64 last_addpath_seq;
-	 
+
+	/* temporary memory for received options that require sending a confirm as response  */
+	u8 cnf_cache[MPDCCP_CONFIRM_SIZE];
+	u8 cnf_cache_len;
+
+	/* temporary memory for resending unconfirmed options, biggest possible option is MP_ADDADDR */
+	u8 reins_cache[MPDCCP_ADDADDR_SIZE];
+
 	/* Scheduler related data */
 	/* Limit in Bytes. Dont forget to adjust when increasing the
 	 * size of any scheduler's priv data struct*/

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -1012,6 +1012,9 @@ int mpdccp_close_subflow (struct mpdccp_cb *mpcb, struct sock *sk, int destroy)
     if (!mpcb || !sk || !mpdccp_my_sock(sk)) return -EINVAL;
     mpdccp_pr_debug("enter for %p role %s state %d closing %d", sk, dccp_role(sk), sk->sk_state, mpdccp_my_sock(sk)->closing);
 
+    if(mpcb->pm_ops->del_retrans)
+        mpcb->pm_ops->del_retrans(sock_net(mpcb->meta_sk), sk);
+
     /* This will call dccp_close() in process context (only once per socket) */
     if (!mpdccp_my_sock(sk)->closing) {
         mpdccp_my_sock(sk)->closing = 1;

--- a/net/dccp/mpdccp_pm.h
+++ b/net/dccp/mpdccp_pm.h
@@ -36,6 +36,7 @@
 /* Maximum lengths for module names */
 #define MPDCCP_PM_NAME_MAX          16
 
+#define pm_jiffies32	((u32)jiffies)
 /*
  * Namespace related functionality
  */
@@ -49,6 +50,9 @@ struct mpdccp_pm_ns {
 	struct list_head	plocal_addr_list;
 	spinlock_t		plocal_lock;
 	
+	struct list_head	retransmit;
+	struct delayed_work	retransmit_worker;
+
 	struct list_head	events;
 	struct delayed_work	address_worker;
 
@@ -75,6 +79,10 @@ struct mpdccp_pm_ops {
 	int 		(*get_hmac)				(struct mpdccp_cb*, u8, sa_family_t, union inet_addr*, u16, bool, u8*);
 	void		(*rcv_removeaddr_opt)   (struct mpdccp_cb*, u8);
 	void 		(*rcv_prio_opt)			(struct sock*, u8, u64);
+
+	int 		(*rcv_confirm_opt)		(struct mpdccp_cb*, u8*, u8);
+	void 		(*store_confirm_opt)	(struct sock*, u8*, u8, u8, u8);
+	void		(*del_retrans)			(struct net*, struct sock*);
 
 	char			name[MPDCCP_PM_NAME_MAX];
 	struct module		*owner;


### PR DESCRIPTION
Implemented MP_CONFIRM option. It's sent to confirm received MP_ADDADDR, MP_REMOVEADDR, and MP_PRIO options.
Furthermore, this commit adds retransmission for unconfirmed options. Currently, retransmission parameters are hard-coded to timeout = 1s and max_retries = 5.
This means that we retransmit an option after 1 second if it is not confirmed. Retransmission will happen up to 5 times with 1 second in between each retransmission.