### PR TITLE
Fixing Issue #29

### DIFF
--- a/net/dccp/feat.c
+++ b/net/dccp/feat.c
@@ -1467,6 +1467,8 @@ int dccp_feat_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 			if (is_mpdccp(sk) && server && (feat == DCCPF_MULTIPATH))
 				return dccp_mpcap_change_recv(dreq, fn, opt, val, len);
+			else if(!is_mpdccp(sk) && server && (feat == DCCPF_MULTIPATH))
+				dccp_push_empty_confirm(fn, DCCPF_MULTIPATH, 1);
 			else
 #endif
 				return dccp_feat_change_recv(fn, mandatory, opt, feat,


### PR DESCRIPTION
In this PR I implemented an mp support check for a link where a request was received. 
If the link from which the DCCP request was recovered does not have the MPDCCPON flag set, all MP-DCCP options will be dropped, and the connection will fall back to regular/single-path DCCP. Also, the response to MP_capable will be empty.