### PR TITLE
Fixing Issue #42

### DIFF
--- a/net/dccp/feat.c
+++ b/net/dccp/feat.c
@@ -1467,6 +1467,8 @@ int dccp_feat_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
 			if (is_mpdccp(sk) && server && (feat == DCCPF_MULTIPATH))
 				return dccp_mpcap_change_recv(dreq, fn, opt, val, len);
+			else if(!is_mpdccp(sk) && server && (feat == DCCPF_MULTIPATH))
+				dccp_push_empty_confirm(fn, DCCPF_MULTIPATH, 1);
 			else
 #endif
 				return dccp_feat_change_recv(fn, mandatory, opt, feat,

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -522,8 +522,11 @@ static void mpdccp_close_worker(struct work_struct *work)
     /* Try again later if the wq is not empty, otherwise dccp_close will invalidate it causing a crash */
     if (skwq_has_sleeper(wq))
         schedule_delayed_work(&mpdccp_my_sock(sk)->close_work, msecs_to_jiffies(200));
-    else
+    else{
+        if(my_sk->closing == 2)
+            dccp_disconnect(sk, 0);
         dccp_close(sk, 0);
+    }
 }
 
 void subflow_write_space(struct sock *sk)
@@ -1017,7 +1020,7 @@ int mpdccp_close_subflow (struct mpdccp_cb *mpcb, struct sock *sk, int destroy)
 
     /* This will call dccp_close() in process context (only once per socket) */
     if (!mpdccp_my_sock(sk)->closing) {
-        mpdccp_my_sock(sk)->closing = 1;
+        mpdccp_my_sock(sk)->closing = destroy;
         mpdccp_pr_debug("Close socket(%p)", sk);
         schedule_delayed_work(&mpdccp_my_sock(sk)->close_work, 0);
     }


### PR DESCRIPTION
The latest commit fixes two bugs.

1. Receiving an MP_REMOVEADDR now triggers `mpdccp_close_subflow(mpcb, sk, 2);`
- closing a subflow with `mpdccp_close_subflow(mpcb, sk, destroy)` destroy == 2 will trigger a dccp_reset() instead of the usual dccp_close()
- This way no traces of the subflow are remaining

2. There was a bug in `pm_del_addr()` where the remote master address with id=0  would not be removed correctly in some cases because of a bad if statement
- changed the if statement so it can only affect local addresses