### PR TITLE
added mpdccp_enabled feature from issue #31 

### DIFF
--- a/include/net/mpdccp.h
+++ b/include/net/mpdccp.h
@@ -52,6 +52,7 @@ struct mpdccp_funcs {
 	int (*xmit_skb) (struct sock*, struct sk_buff*);
 	int (*activate) (struct sock*, int);
 	int (*isactive) (const struct sock*);
+	int (*try_mpdccp) (struct sock*);
 	int (*conn_request) (struct sock *sk, struct dccp_request_sock *dreq);
 	int (*rcv_request_sent_state_process) (struct sock *sk, const struct sk_buff *skb);
 	int (*rcv_respond_partopen_state_process) (struct sock *sk, int type);
@@ -201,6 +202,15 @@ static inline int unregister_mpdccp_subflow_notifier (struct notifier_block *nb)
 }
 #endif
 
+static inline int try_mpdccp (struct sock *sk)
+{
+#if IS_ENABLED(CONFIG_IP_MPDCCP)
+	MPDCCP_CHECK_FUNC(try_mpdccp);
+	return mpdccp_funcs.try_mpdccp (sk);
+#else
+	return 0;
+#endif
+}
 
 static inline int mpdccp_activate (struct sock *sk, int on)
 {

--- a/net/dccp/ipv4.c
+++ b/net/dccp/ipv4.c
@@ -63,7 +63,7 @@ int dccp_v4_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 	if (usin->sin_family != AF_INET)
 		return -EAFNOSUPPORT;
 #if IS_ENABLED(CONFIG_IP_MPDCCP)
-	if (mpdccp_isactive(sk) > 0) {
+	if (mpdccp_isactive(sk) > 0 || try_mpdccp(sk) == 1) {
 		return mpdccp_connect (sk, uaddr, addr_len);
 	}
 #endif

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -88,7 +88,7 @@ static const char *mpdccp_state_name(const int state)
         return dccp_state_names[state];
 }
 #endif
-
+extern int mpdccp_enabled;
 extern bool mpdccp_debug;
 extern bool mpdccp_accept_prio;
 #ifdef CONFIG_IP_MPDCCP_DEBUG

--- a/net/dccp/mpdccp_mod.c
+++ b/net/dccp/mpdccp_mod.c
@@ -51,6 +51,11 @@
 #include "mpdccp_pm.h"
 
 
+int mpdccp_enabled = 1;
+module_param(mpdccp_enabled, int, 0644);
+MODULE_PARM_DESC(mpdccp_enabled, "Enable MPDCCP");
+EXPORT_SYMBOL(mpdccp_enabled);
+
 bool mpdccp_debug;
 module_param(mpdccp_debug, bool, 0644);
 MODULE_PARM_DESC(mpdccp_debug, "Enable debug messages");

--- a/net/dccp/mpdccp_sysctl.c
+++ b/net/dccp/mpdccp_sysctl.c
@@ -244,6 +244,13 @@ static int proc_mpdccp_accept_prio(struct ctl_table *table, int write,
 
 struct ctl_table mpdccp_table[] = {
 	{
+		.procname = "mpdccp_enabled",
+		.data = &mpdccp_enabled,
+		.maxlen = sizeof(int),
+		.mode = 0644,
+		.proc_handler = proc_dointvec,
+	},
+	{
 		.procname = "mpdccp_path_manager",
 		.maxlen = MPDCCP_PM_NAME_MAX,
 		.mode = 0644,


### PR DESCRIPTION
this PR adds mpdccp_enabled syscontrol feature that allows upgrading regular dccp streams to mpdccp if mpdccp_enabled=1
use with e.g. `sysctl -w net.mpdccp.mpdccp_enabled=2`

Currently, the default value is set to 1. This means that regular DCCP streams will be upgraded.