### PR TITLE
fixing dccp path number mismatch in active reoredering for lossdetection (Issue #60)

### DIFF
--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -1123,9 +1123,9 @@ EXPORT_SYMBOL_GPL(mpdccp_xmit_to_sk);
  * and accept the connection */
 int listen_backlog_rcv (struct sock *sk, struct sk_buff *skb)
 {
-    int ret = 0;    
+    int ret = 0;
     struct my_sock *my_sk = mpdccp_my_sock(sk);
-    //struct mpdccp_cb *mpcb  = my_sk->mpcb;
+    struct mpdccp_cb *mpcb  = my_sk->mpcb;
 
     mpdccp_pr_debug("Executing backlog_rcv callback. sk %p my_sk %p bklog %p \n", sk, my_sk, my_sk->sk_backlog_rcv);
 
@@ -1133,7 +1133,9 @@ int listen_backlog_rcv (struct sock *sk, struct sk_buff *skb)
 	mpdccp_pr_debug("There is sk_backlog_rcv");
         ret = my_sk->sk_backlog_rcv (sk, skb);
     }
-   
+
+    if(mpcb && mpcb->reorder_ops->update_pseq)
+        mpcb->reorder_ops->update_pseq(my_sk, skb);
 #if 0 
     /* If the queue was previously stopped because of a full cwnd,
     * a returning ACK will open the window again, so we should

--- a/net/dccp/mpdccp_reordering.h
+++ b/net/dccp/mpdccp_reordering.h
@@ -145,6 +145,7 @@ struct mpdccp_reorder_ops {
 	
 	void			(*init) (struct mpdccp_cb *mpcb);
 	void			(*do_reorder) (struct rcv_buff *w);
+	void			(*update_pseq) (struct my_sock *, struct sk_buff *);
 	
 	char			name[MPDCCP_REORDER_NAME_MAX];
 	struct module		*owner;

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -1096,8 +1096,6 @@ void dccp_insert_options_mp(struct sock *sk, struct sk_buff *skb)
 	/* Insert delay value (sub-flow specific) as DCCP option */
 	switch(DCCP_SKB_CB(skb)->dccpd_type){
 	case DCCP_PKT_DATAACK:
-		dccp_insert_option_mp_seq(skb, &mpcb->mp_oall_seqno, mpcb->do_incr_oallseq);
-		
 		if(!(mpcb->mp_oall_seqno % 1)){				//try sending mp_rtt with every x dataack	
 			struct tcp_info info;
 			u8 rtt_type;
@@ -1110,6 +1108,7 @@ void dccp_insert_options_mp(struct sock *sk, struct sk_buff *skb)
 						rtt_value, rtt_type, rtt_age, sk, mp_addr_id, my_sk->remote_addr_id);
 			}
 		}
+		dccp_insert_option_mp_seq(skb, &mpcb->mp_oall_seqno, mpcb->do_incr_oallseq);
 		break;
 	case DCCP_PKT_DATA:
 		if(my_sk->delpath_id && mpcb->pm_ops->get_hmac){

--- a/net/dccp/reordering/ro_default.c
+++ b/net/dccp/reordering/ro_default.c
@@ -61,12 +61,15 @@ static void do_reorder_default(struct rcv_buff *rb)
 	return; 
 }
 
+void do_update_pseq(struct my_sock *my_sk, struct sk_buff *skb){}
+
 /**
  * Initialize active reordering operations.
  */
 struct mpdccp_reorder_ops mpdccp_reorder_default = {
 	.init		= init_reorder_default,
 	.do_reorder	= do_reorder_default,
+	.update_pseq = do_update_pseq,
 	.name		= "default",
 	.owner		= THIS_MODULE,
 };


### PR DESCRIPTION
I added a new function to the reordering that updates path sequence number for all received packets.
Furthermore, I changed MP_SEQ options to always be the first option that is attached when sending a packet.
