### PR TITLE
fixing TIME_WAIT bug that happens when mpdccp fast_close is used

### DIFF
--- a/net/dccp/input.c
+++ b/net/dccp/input.c
@@ -176,10 +176,12 @@ static void dccp_rcv_reset(struct sock *sk, struct sk_buff *skb)
 		switch (sk->sk_state) {
 		case DCCP_OPEN:
 			dccp_set_state(sk, DCCP_PASSIVE_CLOSE);
+		case DCCP_PASSIVE_CLOSE:
 			return;
 		case DCCP_ACTIVE_CLOSEREQ:
 			dccp_send_reset(sk, DCCP_RESET_CODE_MPDCCP_ABORTED);
-			break;
+			dccp_done(sk);
+			return;
 		}
 	}
 

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -1021,6 +1021,10 @@ int mpdccp_close_subflow (struct mpdccp_cb *mpcb, struct sock *sk, int destroy)
     if(mpcb->pm_ops->del_retrans)
         mpcb->pm_ops->del_retrans(sock_net(mpcb->meta_sk), sk);
 
+    if(mpcb->close_fast == 2 && sk->sk_state == DCCP_OPEN){
+        dccp_set_state(sk, DCCP_PASSIVE_CLOSE);
+    }
+
     /* This will call dccp_close() in process context (only once per socket) */
     if (!mpdccp_my_sock(sk)->closing) {
         mpdccp_my_sock(sk)->closing = destroy;

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -1297,7 +1297,7 @@ int dccp_insert_options_rsk_mp(const struct sock *sk, struct dccp_request_sock *
 		struct mpdccp_cb *mpcb = get_mpcb(dreq->meta_sk);
 		int loc_id = 0;
 
-		if (!mpcb) {
+		if (!mpcb || mpcb->to_be_closed) {
 			dccp_pr_debug("(%s) invalid MPCB", dccp_role(sk));
 			return -1;
 		}


### PR DESCRIPTION
This is a fix for the problem explained in Issue #66. It prevents the server from entering TIME_WAIT state after closing an MPDCCP connection using fast_close.