### PR TITLE
fixing the issues mentioned in #64 and #65

### DIFF
--- a/net/dccp/non_gpl_scheduler/sched_acpf.c
+++ b/net/dccp/non_gpl_scheduler/sched_acpf.c
@@ -494,7 +494,7 @@ struct sock *mpdccp_acpfsched(struct mpdccp_cb *mpcb)
 		return mpdccp_return_single_flow(mpcb);
 	}
 
-	rcu_read_lock();
+	rcu_read_lock_bh();
 
 	// Determine ACPF mode
 	mpdccp_for_each_sk(mpcb, sk) {
@@ -517,7 +517,7 @@ struct sock *mpdccp_acpfsched(struct mpdccp_cb *mpcb)
 		update_frac(sk);
 	}
 
-	rcu_read_unlock();
+	rcu_read_unlock_bh();
 
 	if (best_sk)
 		mpdccp_pr_debug("ACPF returned socket %p\n", best_sk);

--- a/net/dccp/pm/pm_default.c
+++ b/net/dccp/pm/pm_default.c
@@ -793,7 +793,7 @@ static bool mpdccp_del_addr(struct mpdccp_pm_ns *pm_ns,
 				found = true;
 				addr_id = local_addr->id;
 				list_del_rcu(&local_addr->address_list);
-				kfree_rcu(local_addr, rcu);
+				kmem_cache_free(mpdccp_pm_addr_cache, local_addr);
 			}
 		}
 	}

--- a/net/dccp/scheduler/sched_redundant.c
+++ b/net/dccp/scheduler/sched_redundant.c
@@ -90,7 +90,7 @@ struct sock *mpdccp_redsched(struct mpdccp_cb *mpcb)
 			continue;
 		}
 		
-		if(!mpdccp_packet_fits_in_cwnd(sk) && !dccp_ack_pending(sk)){
+		if(!mpdccp_packet_fits_in_cwnd(sk)){ // && !dccp_ack_pending(sk)
 			mpdccp_pr_debug("Packet does not fit in cwnd of %p. Continuing...\n", sk);
 			continue;
 		}

--- a/net/dccp/scheduler/sched_rr.c
+++ b/net/dccp/scheduler/sched_rr.c
@@ -75,7 +75,7 @@ retry:
 			continue;
 		}
 		
-		if(!mpdccp_packet_fits_in_cwnd(sk) && !dccp_ack_pending(sk)){
+		if(!mpdccp_packet_fits_in_cwnd(sk)){ //&& !dccp_ack_pending(sk)
 			mpdccp_pr_debug("Packet does not fit in cwnd of %p. Continuing...\n", sk);
 			continue;
 		}

--- a/net/dccp/scheduler/sched_srtt.c
+++ b/net/dccp/scheduler/sched_srtt.c
@@ -77,7 +77,7 @@ static struct sock *mpdccp_srttsched(struct mpdccp_cb *mpcb)
 			continue;
 		}
 		
-		if (!mpdccp_packet_fits_in_cwnd(sk) && !dccp_ack_pending(sk)){
+		if (!mpdccp_packet_fits_in_cwnd(sk)){ // && !dccp_ack_pending(sk)
 			mpdccp_pr_debug("Packet does not fit in cwnd of %p. Continuing...\n", sk);
 			continue;
 		}


### PR DESCRIPTION
This PR has 3 small fixes.
I removed the check for dccp_ack_pending in the schedulers. This was causing the problems in #64 and #65, because with ccid2, it would always return true.

In the path manager, kmem_cache_free() should be used to free memory that was allocated with kmem_cache_create() instead of kfree().

 In mpdccp_ctrl.c I fixed some indenting issues and removed some unecessary calls to mpdccp_my_sock(sk).