### PR TITLE
Connection ID update

### DIFF
--- a/include/linux/dccp.h
+++ b/include/linux/dccp.h
@@ -180,6 +180,8 @@ struct dccp_request_sock {
 	struct mpdccp_key	mpdccp_rem_key;
 	u32			mpdccp_loc_token;
 	u32			mpdccp_rem_token;
+	u32 		mpdccp_loc_cix;
+	u32 		mpdccp_rem_cix;
 	u32	 		mpdccp_loc_nonce;
 	u32 			mpdccp_rem_nonce;
 	u8 			mpdccp_loc_hmac[MPDCCP_HMAC_SIZE];
@@ -222,6 +224,7 @@ struct dccp_options_received {
 	u32 dccpor_rtt_age;
 	u8 dccpor_mp_suppkeys;			/* MPDCCP supported key types */
 	u32 dccpor_mp_token;			/* MPDCCP path token */
+	u32 dccpor_mp_cix;			/* MPDCCP Connection ID */
 	u32 dccpor_mp_nonce;			/* MPDCCP path nonce */
 	u8 dccpor_mp_hmac[MPDCCP_HMAC_SIZE];	/* MPDCCP HMAC */
 	struct mpdccp_key dccpor_mp_keys[MPDCCP_MAX_KEYS];	/* MPDCCP keys */

--- a/include/linux/dccp.h
+++ b/include/linux/dccp.h
@@ -178,8 +178,6 @@ struct dccp_request_sock {
 	struct mpdccp_link_info  *link_info;
 	struct mpdccp_key	mpdccp_loc_key;
 	struct mpdccp_key	mpdccp_rem_key;
-	u32			mpdccp_loc_token;
-	u32			mpdccp_rem_token;
 	u32 		mpdccp_loc_cix;
 	u32 		mpdccp_rem_cix;
 	u32	 		mpdccp_loc_nonce;

--- a/include/net/mpdccp_link.h
+++ b/include/net/mpdccp_link.h
@@ -96,7 +96,9 @@ static inline int dev_change_mpdccp_resetstat(struct net_device *dev)
 	return mpdccp_link_change_mpdccp_resetstat(MPDCCP_LINK_FROM_DEV(dev));
 }
 
-
+/* Connection ID functions  */
+u32 mpdccp_link_generate_cid(void);
+void mpdccp_link_free_cid(u32 cid);
 /* 
  * find functions
  */

--- a/net/dccp/ipv4.c
+++ b/net/dccp/ipv4.c
@@ -575,6 +575,10 @@ static void dccp_v4_reqsk_destructor(struct request_sock *req)
 		sock_put(dreq->meta_sk);
 		dreq->meta_sk = NULL;
 	}
+	if (dreq->mpdccp_loc_cix) {
+		mpdccp_link_free_cid(dreq->mpdccp_loc_cix);
+		dreq->mpdccp_loc_cix = 0;
+	}
 #endif
 
 	dccp_feat_list_purge(&dccp_rsk(req)->dreq_featneg);

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -286,8 +286,6 @@ struct mpdccp_cb {
 	u8			dkeyA[MPDCCP_MAX_KEY_SIZE * 2];
 	u8			dkeyB[MPDCCP_MAX_KEY_SIZE * 2];
 	int			dkeylen;
-	u32			mpdccp_loc_token;
-	u32			mpdccp_rem_token;
 	u32			mpdccp_loc_cix;
 	u32			mpdccp_rem_cix;
 	int			kex_done;

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -288,6 +288,8 @@ struct mpdccp_cb {
 	int			dkeylen;
 	u32			mpdccp_loc_token;
 	u32			mpdccp_rem_token;
+	u32			mpdccp_loc_cix;
+	u32			mpdccp_rem_cix;
 	int			kex_done;
 	u8			mpdccp_suppkeys;
 	int			cur_key_idx;
@@ -386,7 +388,7 @@ int mpdccp_deinit_funcs (void);
 int mpdccp_report_new_subflow (struct sock*);
 int mpdccp_report_destroy (struct sock*);
 int mpdccp_report_alldown (struct sock*);
-
+u32 mpdccp_generate_ci(void);
 
 
 int mpdccp_add_client_conn (struct mpdccp_cb *, struct sockaddr *local, int llen, int if_idx, struct sockaddr *rem, int rlen);

--- a/net/dccp/mpdccp.h
+++ b/net/dccp/mpdccp.h
@@ -386,7 +386,6 @@ int mpdccp_deinit_funcs (void);
 int mpdccp_report_new_subflow (struct sock*);
 int mpdccp_report_destroy (struct sock*);
 int mpdccp_report_alldown (struct sock*);
-u32 mpdccp_generate_ci(void);
 
 
 int mpdccp_add_client_conn (struct mpdccp_cb *, struct sockaddr *local, int llen, int if_idx, struct sockaddr *rem, int rlen);

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -379,6 +379,7 @@ int mpdccp_destroy_mpcb(struct mpdccp_cb *mpcb)
 	mpdccp_cleanup_path_manager(mpcb);
 
 	/* release and eventually free mpcb */   
+    mpdccp_link_free_cid(mpcb->mpdccp_loc_cix);
 	mpdccp_cb_put (mpcb);
 	
 	return 0;

--- a/net/dccp/mpdccp_ctrl.c
+++ b/net/dccp/mpdccp_ctrl.c
@@ -837,32 +837,12 @@ int mpdccp_add_client_conn (	struct mpdccp_cb *mpcb,
 	if (dccp_sk(sk)->is_kex_sk && mpcb->kex_done) {
 		struct inet_sock *inet_meta = inet_sk(mpcb->meta_sk);
 		struct inet_sock *inet_sub = inet_sk(sk);
-		u32 token;
 
 		/* MP_KEY sockets can be authorized now. MP_JOIN sockets need to wait one more more ack */
 		dccp_sk(sk)->auth_done = 1;
 
 		/* Reset the flag to avoid inserting MP_KEY options in subsenquent ACKs */
 		dccp_sk(sk)->is_kex_sk = 0;
-
-		/* Create local token */
-		ret = mpdccp_hash_key(mpcb->dkeyA, mpcb->dkeylen, &token);
-		if (ret) {
-			mpdccp_pr_debug("error hashing dkeyA, err %d", ret);
-			sock_release(sock);
-			goto out;
-		}
-		mpcb->mpdccp_loc_token = token;
-
-		/* Create remote token */
-		ret = mpdccp_hash_key(mpcb->dkeyB, mpcb->dkeylen, &token);
-		if (ret) {
-			mpdccp_pr_debug("error hashing dkeyB, err %d", ret);
-			sock_release(sock);
-			goto out;
-		}
-		mpcb->mpdccp_rem_token = token;
-		mpdccp_pr_debug("client: kex done lt: %x rt: %x", mpcb->mpdccp_loc_token, mpcb->mpdccp_rem_token);
 
 		/* Update the state and MSS of meta socket */
 		dccp_sk(mpcb->meta_sk)->dccps_mss_cache = dccp_sk(sk)->dccps_mss_cache;
@@ -1264,23 +1244,6 @@ void mpdccp_init_announce_prio(struct sock *sk)
     mpdccp_my_sock(sk)->announce_prio = mpdccp_get_prio(sk) + 1;        //adding +1 so we can check also for sending zero
     dccp_send_keepalive(sk);
 }
-
-int mpdccp_hash_key(const u8 *key, u8 keylen, u32 *token)
-{
-        SHASH_DESC_ON_STACK(desc, tfm_hash);
-        int ret;
-        u32 buf[8];
-
-        desc->tfm = tfm_hash;
-        desc->flags = 0;
-        ret = crypto_shash_digest(desc, key, keylen, (u8*)buf);
-
-        if (token)
-            *token = buf[0];
-
-        return ret;
-}
-EXPORT_SYMBOL(mpdccp_hash_key);
 
 int mpdccp_generate_key(struct mpdccp_key *key, int key_type)
 {

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -1177,19 +1177,9 @@ void dccp_insert_options_mp(struct sock *sk, struct sk_buff *skb)
 		}
 		break;
 	case DCCP_PKT_ACK:
-		if (dccp_sk(sk)->is_kex_sk) {
-			dccp_pr_debug("(%s) ACK insert opt MP_KEY %llx %llx",
-							dccp_role(sk),
-							be64_to_cpu(*((__be64*)mpcb->mpdccp_loc_keys[mpcb->cur_key_idx].value)),
-							be64_to_cpu(*((__be64*)mpcb->mpdccp_rem_key.value)));
-			/* Insert local & remote key */
-			dccp_insert_option_mp_key(skb, mpcb, NULL);
-		} else {
-			if (!dccp_sk(sk)->auth_done){
-				/* Insert HMAC */
-				dccp_pr_debug("(%s) ACK insert opt MP_HMAC %llx", dccp_role(sk),be64_to_cpu(*((u64*)dccp_sk(sk)->mpdccp_loc_hmac)));
-				dccp_insert_option_mp_hmac(skb, dccp_sk(sk)->mpdccp_loc_hmac);
-			}
+		if (!dccp_sk(sk)->auth_done) {
+			dccp_pr_debug("(%s) ACK insert opt MP_HMAC %llx", dccp_role(sk),be64_to_cpu(*((u64*)dccp_sk(sk)->mpdccp_loc_hmac)));
+			dccp_insert_option_mp_hmac(skb, dccp_sk(sk)->mpdccp_loc_hmac);
 		}
 		break;
 	case DCCP_PKT_CLOSE:

--- a/net/dccp/options.c
+++ b/net/dccp/options.c
@@ -361,7 +361,7 @@ int dccp_parse_options(struct sock *sk, struct dccp_request_sock *dreq,
 				opt_recv->dccpor_mp_nonce = get_unaligned_be32(value);
 
 				dccp_pr_debug("%s rx opt: DCCPO_MP_JOIN = addrID %u on %pI4:%u from " \
-								"%pI4:%u, CI %x nonce %x, sk %p",
+								"%pI4:%u, CID %u nonce %x, sk %p",
 								dccp_role(sk), opt_recv->dccpor_join_id,
 								&ip_hdr(skb)->daddr, htons(dccp_hdr(skb)->dccph_dport),
 								&ip_hdr(skb)->saddr, htons(dccp_hdr(skb)->dccph_sport),
@@ -1183,7 +1183,7 @@ void dccp_insert_options_mp(struct sock *sk, struct sk_buff *skb)
 		}
 		break;
 	case DCCP_PKT_ACK:
-		if (!dccp_sk(sk)->auth_done) {
+		if (!dccp_sk(sk)->auth_done && !dccp_sk(sk)->is_kex_sk) {
 			dccp_pr_debug("(%s) ACK insert opt MP_HMAC %llx", dccp_role(sk),be64_to_cpu(*((u64*)dccp_sk(sk)->mpdccp_loc_hmac)));
 			dccp_insert_option_mp_hmac(skb, dccp_sk(sk)->mpdccp_loc_hmac);
 		}


### PR DESCRIPTION
This PR brings the implementation back in line with the draft. (See issue #77) 

There are three commits that belong to this update:

1. The first commit removes the third MP_KEY message. This message was used to verify the keys after sharing but it is not needed. Previously the shared information was only stored after the third MP_KEY. It is now handled after the first received MP_KEY message. The DCCP_ACK packet is still sent but the final MP_KEY is not attached.
2.  The second commit extends the MP_KEY option by 5 bytes (1 byte reserved and 4 bytes for the CI (connection identifier)). Recovered CI's are also stored in memory.
3. The last commit adds the remaining functionalities and updates the MP_JOIN option, as well as the HMAC calculation for the MP_JOIN messages.