### PR TITLE
changed workflow trigger from closed PR to push

### DIFF
--- a/.github/workflows/kernel4.yml
+++ b/.github/workflows/kernel4.yml
@@ -1,9 +1,7 @@
 name: Compile and Package Kernel v4.14
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - mpdccp_v03_k4.14
   workflow_dispatch:
@@ -37,7 +35,7 @@ jobs:
           '
 
       - name: Upload .deb files to repository
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Kernel-deb-files
           path: ${{ github.workspace }}/pkgs
@@ -51,7 +49,7 @@ jobs:
         with:
           ref: release_4
       - name: Receive debian files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "Kernel-deb-files"
       - name: Deploy to Release Branch

--- a/.github/workflows/kernel5.yml
+++ b/.github/workflows/kernel5.yml
@@ -1,9 +1,7 @@
 name: Compile and Package Kernel v5.10
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - mpdccp_v03_k5.10
   workflow_dispatch:
@@ -20,7 +18,7 @@ jobs:
           remove-dotnet: 'true'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: mpdccp_v03_k5.10
 
@@ -37,7 +35,7 @@ jobs:
           '
 
       - name: Upload .deb files to repository
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Kernel-deb-files
           path: ${{ github.workspace }}/pkgs
@@ -51,7 +49,7 @@ jobs:
         with:
           ref: release_5
       - name: Receive debian files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "Kernel-deb-files"
       - name: Deploy to Release Branch


### PR DESCRIPTION
This PR updates the workflow files so that actions are also triggered by direct pushes to the repo instead of only closed PRs
Furthermore, updated to version 4 for handling artifacts.
This should also fix the problems with uploads to the release branch.