### PR TITLE
Fix for the default scheduler

### DIFF
--- a/net/dccp/scheduler/sched_default.c
+++ b/net/dccp/scheduler/sched_default.c
@@ -35,11 +35,9 @@ struct sock *sched_default (struct mpdccp_cb *mpcb)
 
     rcu_read_lock();
     mpdccp_for_each_sk(mpcb, sk) {
-        if(!mpdccp_sk_can_send(sk)) continue;
-        if(!mpdccp_packet_fits_in_cwnd(sk) && !dccp_ack_pending(sk)) continue;
-
-	rcu_read_unlock();
-	return sk;
+        if(!mpdccp_sk_can_send(sk) || !mpdccp_packet_fits_in_cwnd(sk)) continue;
+        rcu_read_unlock();
+        return sk;
     }
 
     rcu_read_unlock();


### PR DESCRIPTION
This PR fixes the issue with the default scheduler mentioned in #64.
The call to `dccp_ack_pending(sk)` is removed because it always return true (for ccid2).